### PR TITLE
Apply opacity to all section classes on the page

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -212,7 +212,7 @@ def _render_mm_html_raw(self, node, code, options, prefix='mermaid',
         # workaround for https://github.com/knsv/mermaid/issues/527
         self.body.append("""
             <style>
-            .body .section {
+            .section {
                 opacity: 1.0 !important;
             }
             </style>


### PR DESCRIPTION
Related to https://github.com/mgaitan/sphinxcontrib-mermaid/issues/7

Initially I was thinking that [read-the-docs](http://docs.readthedocs.io/en/latest/theme.html) theme is using `.section` tag all over the page. But then looked at a workaround again and noticed it's `.body` (not `body`) which makes browser only look for `.body` class instead of a tag.

Both removing `.body` and changing it to `body` fixes the [opacity issue](https://github.com/knsv/mermaid/issues/527) for read-the-docs users. I'm not a css expert but I didn't see much `body .<class>` used in css files, so I suggest just removing `.body`.

Thanks for your work on this extension.