### PR TITLE
fixed latex integration: includegraphics changed to sphinxincludegraphics

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -296,7 +296,7 @@ def render_mm_latex(self, node, code, options, prefix='mermaid'):
             elif node['align'] == 'right':
                 self.body.append('{\\hspace*{\\fill}')
                 post = '}'
-        self.body.append('%s\\includegraphics{%s}%s' %
+        self.body.append('%s\\sphinxincludegraphics{%s}%s' %
                          (para_separator, fname, para_separator))
         if post:
             self.body.append(post)


### PR DESCRIPTION
Hi,

I updated the module again to support the integrated sphinxincludegraphics latex macro.
With this, images cannot be wider than the page anymore.