### PR TITLE
added pdfcrop functionality and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,11 @@ Config values
     Use the verbose mode when call mermaid-cli, and show its output in the building
     process.
 
+``mermaid_pdfcrop``
+
+    If using latex output, it might be useful to crop the pdf just to the needed space. For this, ``pdfcrop`` can be used.
+    State binary name to use this extra function.
+
 Acknowledge
 -----------
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -302,7 +302,7 @@ def render_mm_latex(self, node, code, options, prefix='mermaid'):
             raise MermaidError('PdfCrop did not produce an output file:\n[stderr]\n%s\n'
                                 '[stdout]\n%s' % (stderr, stdout))
 
-        fname = os.path.splitext(fname)[0] + "-crop" + os.path.splitext(fname)[1]
+        fname = '{filename[0]}-crop{filename[1]}'.format(filename=os.path.splitext(fname))
 
     is_inline = self.is_inline(node)
     if is_inline:


### PR DESCRIPTION
Hi,
I have a proposition for more functionality, but it will bring an additional dependency.

With this patch, you can use the mermaid_pdfcrop directive to use the pdfcrop utility on linux systems.
It will crop the pdf output of mermaid to the useful area so that an image that is not the default width/height doesn't take up too much space.

BR Bastian