### PR TITLE
version 8 no longer RC

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -32,7 +32,7 @@ from .autoclassdiag import ClassDiagram
 
 mapname_re = re.compile(r'<map id="(.*?)"')
 
-VERSION = '8.0.0-rc.8'
+VERSION = '8.0.0'
 BASE_URL = 'https://unpkg.com/mermaid@{}/dist'.format(VERSION)
 JS_URL = '{}/mermaid.min.js'.format(BASE_URL)
 CSS_URL = None # css is contained in the js bundle


### PR DESCRIPTION
This removes the release-candidate suffix, as mermaid is now in stable 8.0.0 release.  closes #24 