### PR TITLE
Fix UnicodeEncodeError on Python 2

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -10,6 +10,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+from __future__ import unicode_literals
+
 import re
 import codecs
 import posixpath


### PR DESCRIPTION
Fix issue https://github.com/mgaitan/sphinxcontrib-mermaid/issues/33

I used the code below for use `unicode` as the default string literals in Python 2.

```python
from __future__ import unicode_literals
```