### PR TITLE
Updated Base URL and Version

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 mapname_re = re.compile(r'<map id="(.*?)"')
 
 VERSION = '8.4.4'
-BASE_URL = 'https://cdnjs.cloudflare.com/ajax/libs/{}'.format(VERSION)
+BASE_URL = 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/{}'.format(VERSION)
 JS_URL = '{}/mermaid.min.js'.format(BASE_URL)
 CSS_URL = None # css is contained in the js bundle
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -35,8 +35,8 @@ logger = logging.getLogger(__name__)
 
 mapname_re = re.compile(r'<map id="(.*?)"')
 
-VERSION = '8.0.0'
-BASE_URL = 'https://unpkg.com/mermaid@{}/dist'.format(VERSION)
+VERSION = '8.4.4'
+BASE_URL = 'https://cdnjs.cloudflare.com/ajax/libs/{}'.format(VERSION)
 JS_URL = '{}/mermaid.min.js'.format(BASE_URL)
 CSS_URL = None # css is contained in the js bundle
 


### PR DESCRIPTION
Bumped to version 8.4.4
The current CDN unpkg.com violates CSP policy making it hard to add inline scripts. Changing this to cloudfare might help. Anyway, it's better to bump the version