### PR TITLE
Make mermaid version configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ Config values
 
    Also note ``'svg'`` support is very experimental in mermaid.
 
+``mermaid_version``
+
+  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on https://unpkg.com/browse/mermaid@8.0.0/. The default version is 8.0.0.
 
 ``mermaid_cmd``
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -35,9 +35,6 @@ logger = logging.getLogger(__name__)
 
 mapname_re = re.compile(r'<map id="(.*?)"')
 
-VERSION = '8.0.0'
-BASE_URL = 'https://unpkg.com/mermaid@{}/dist'.format(VERSION)
-JS_URL = '{}/mermaid.min.js'.format(BASE_URL)
 CSS_URL = None # css is contained in the js bundle
 
 
@@ -199,9 +196,8 @@ def render_mm(self, code, options, format, prefix='mermaid'):
 
 def _render_mm_html_raw(self, node, code, options, prefix='mermaid',
                    imgcls=None, alt=None):
-
-    if JS_URL not in self.builder.script_files:
-        self.builder.script_files.append(JS_URL)
+    if self._mermaid_js_url not in self.builder.script_files:
+        self.builder.script_files.append(self._mermaid_js_url)
     if CSS_URL and CSS_URL not in self.builder.css_files:
         self.builder.css_files.append(CSS_URL)
     if "mermaid issue 527 workaround" not in self.body:
@@ -234,7 +230,8 @@ def _render_mm_html_raw(self, node, code, options, prefix='mermaid',
 
 def render_mm_html(self, node, code, options, prefix='mermaid',
                    imgcls=None, alt=None):
-
+    version = self.builder.config.mermaid_version
+    self._mermaid_js_url = 'https://unpkg.com/mermaid@{}/dist/mermaid.min.js'.format(version)
     format = self.builder.config.mermaid_output_format
     if format == 'raw':
         return _render_mm_html_raw(self, node, code, options, prefix='mermaid',
@@ -382,5 +379,6 @@ def setup(app):
     app.add_config_value('mermaid_params', list(), 'html')
     app.add_config_value('mermaid_verbose', False, 'html')
     app.add_config_value('mermaid_sequence_config', False, 'html')
+    app.add_config_value('mermaid_version', '8.0.0', 'html')
 
     return {'version': sphinx.__display_version__, 'parallel_read_safe': True}


### PR DESCRIPTION
Instead of hardcoding the mermaid version number in mermaid.py, let
users configure the version in their conf.py and user the currently hardcoded
version as the default mermaid version.

ref: #20