### PR TITLE
Added mermaid_cmd_shell command line argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# IDEA project settings
+.idea

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,10 @@ Config values
 
    The command name with which to invoke ``mermaid-cli`` program.  The default is ``'mmdc'``; you may need to set this to a full path if it's not in the executable search path.
 
+``mermaid_cmd_shell``
+
+   When set to true, the ``shell=True`` argument will be passed the process execution command.  This allows commands other than binary executables to be executed on Windows.  The default is false.
+
 ``mermaid_params``
 
    For individual parameters, a list of parameters can be added. Refer to `<https://github.com/mermaidjs/mermaid.cli#options>`_.

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -154,6 +154,7 @@ def render_mm(self, code, options, format, prefix='mermaid'):
         format = 'png'
 
     mermaid_cmd = self.builder.config.mermaid_cmd
+    mermaid_cmd_shell = self.builder.config.mermaid_cmd_shell in {True, 'True', 'true'}
     hashkey = (code + str(options) + str(self.builder.config.mermaid_sequence_config)).encode('utf-8')
 
     basename = '%s-%s' % (prefix, sha1(hashkey).hexdigest())
@@ -181,7 +182,7 @@ def render_mm(self, code, options, format, prefix='mermaid'):
        mm_args.extend('--configFile', self.builder.config.mermaid_sequence_config)
 
     try:
-        p = Popen(mm_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+        p = Popen(mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE)
     except OSError as err:
         if err.errno != ENOENT:   # No such file or directory
             raise
@@ -372,6 +373,7 @@ def setup(app):
 
     #
     app.add_config_value('mermaid_cmd', 'mmdc', 'html')
+    app.add_config_value('mermaid_cmd_shell', 'False', 'html')
     app.add_config_value('mermaid_pdfcrop', '', 'html')
     app.add_config_value('mermaid_output_format', 'raw', 'html')
     app.add_config_value('mermaid_params', list(), 'html')


### PR DESCRIPTION
When mermaid_cmd_shell is set to `True`, or the string value `"true"` or `"True"`, the argument `shell=True` will be passed to the `Popen()` call.

This allows executing commands on Windows that aren't binary executables.

This addresses the issue described in https://github.com/mgaitan/sphinxcontrib-mermaid/issues/4