### PR TITLE
Converting code to binary before processing

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -180,7 +180,7 @@ def render_mm(self, code, options, format, prefix='mermaid'):
                        'output), check the mermaid_cmd setting' % mermaid_cmd)
         return None, None
 
-    stdout, stderr = p.communicate(code)
+    stdout, stderr = p.communicate(str.encode(code))
     if self.builder.config.mermaid_verbose:
         logger.info(stdout)
 


### PR DESCRIPTION
Replacing `wb` to `w` broken the p.communicate, which does not accept a string, this is the stacktrace:

```
Traceback (most recent call last):
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app.build(args.force_all, filenames)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/application.py", line 352, in build
    self.builder.build_update()
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 298, in build_update
    len(to_build))
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 360, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 534, in write
    self._write_serial(sorted(docnames))
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 544, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/builders/html/__init__.py", line 597, in write_doc
    self.docwriter.write(doctree, destination)
  File "/home/circleci/.local/lib/python3.7/site-packages/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/writers/html.py", line 71, in translate
    self.document.walkabout(visitor)
  File "/home/circleci/.local/lib/python3.7/site-packages/docutils/nodes.py", line 178, in walkabout
    if child.walkabout(visitor):
  File "/home/circleci/.local/lib/python3.7/site-packages/docutils/nodes.py", line 178, in walkabout
    if child.walkabout(visitor):
  File "/home/circleci/.local/lib/python3.7/site-packages/docutils/nodes.py", line 178, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 1 more time]
  File "/home/circleci/.local/lib/python3.7/site-packages/docutils/nodes.py", line 170, in walkabout
    visitor.dispatch_visit(self)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinx/util/docutils.py", line 468, in dispatch_visit
    method(node)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinxcontrib/mermaid.py", line 267, in html_visit_mermaid
    render_mm_html(self, node, node['code'], node['options'])
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinxcontrib/mermaid.py", line 238, in render_mm_html
    fname, outfn = render_mm(self, code, options, format, prefix)
  File "/home/circleci/.local/lib/python3.7/site-packages/sphinxcontrib/mermaid.py", line 183, in render_mm
    stdout, stderr = p.communicate(code)
  File "/usr/local/lib/python3.7/subprocess.py", line 964, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/local/lib/python3.7/subprocess.py", line 1695, in _communicate
    input_view = memoryview(self._input)
TypeError: memoryview: a bytes-like object is required, not 'str'
``` 

This PR converts the content to binary on p.communicate call