### PR TITLE
Fix typo introduced in 54fafa0 which broke config read

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -225,7 +225,7 @@ def render_mm_html(self, node, code, options, prefix='mermaid',
     else:
         self._mermaid_js_url = f"https://unpkg.com/mermaid@{self.builder.config.mermaid_version}/dist/mermaid.min.js"
 
-    _fmt = self.builder.config.mermaid_output__fmt
+    _fmt = self.builder.config.mermaid_output_format
     if _fmt == 'raw':
         return _render_mm_html_raw(self, node, code, options, prefix='mermaid',
                    imgcls=None, alt=None)


### PR DESCRIPTION
Looks like just an overambitious find/replace which caused an error while getting `mermaid_output_format` from Sphinx's `config.py`