### PR TITLE
Adapt to upcoming Sphinx==4.0 release

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -24,7 +24,7 @@ from docutils.statemachine import ViewList
 import sphinx
 from sphinx.locale import _
 from sphinx.util.i18n import search_image_for_language
-from sphinx.util.osutil import ensuredir, ENOENT
+from sphinx.util.osutil import ensuredir
 from sphinx.util import logging
 from .exceptions import MermaidError
 from .autoclassdiag import class_diagram
@@ -173,9 +173,7 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
 
     try:
         p = Popen(mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    except OSError as err:
-        if err.errno != ENOENT:   # No such file or directory
-            raise
+    except FileNotFoundError:
         logger.warning('command %r cannot be run (needed for mermaid '
                        'output), check the mermaid_cmd setting' % mermaid_cmd)
         return None, None

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -7,13 +7,14 @@ def build_all(app):
 
 @pytest.fixture
 def index(app, build_all):
-    return (app.outdir / 'index.html').read_text()
+    # normalize script tag for compat to Sphinx<4
+    return (app.outdir / 'index.html').read_text().replace("<script >", "<script>")
 
 
 @pytest.mark.sphinx('html', testroot="basic")
 def test_html_raw(index):
     assert '<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>' in index
-    assert "<script >mermaid.initialize({startOnLoad:true});</script>" in index
+    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
     assert """<div class="mermaid">
             sequenceDiagram
    participant Alice
@@ -36,14 +37,14 @@ def test_conf_mermaid_no_version(app, index):
 
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_init_js': "custom script;"})
 def test_mermaid_init_js(index):
-    assert "<script >mermaid.initialize({startOnLoad:true});</script>" not in index
-    assert '<script >custom script;</script>' in index
+    assert "<script>mermaid.initialize({startOnLoad:true});</script>" not in index
+    assert '<script>custom script;</script>' in index
 
 
 @pytest.mark.sphinx('html', testroot="markdown")
 def test_html_raw_from_markdown(index):
     assert '<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>' in index
-    assert "<script >mermaid.initialize({startOnLoad:true});</script>" in index
+    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
     assert """
 <div class="mermaid">
             sequenceDiagram


### PR DESCRIPTION
Close #72.

`sphinx.util.osutil.ENOENT` is deprecated since Sphinx==2.0 and is removed in the upcoming 4.0 release, breaking compatibility. Since Python 2 is not supported by Sphinx anymore anyway, `FileNotFoundError` is used instead. Other than that, I have adjusted tests to work with 4.0.

@mgaitan if you approve the PR, can you publish the next release early enough so we are prepared for the upcoming 4.0 release on 8th May?

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>