### PR TITLE
Fix #68 by setting mermaid init JS priority

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -352,7 +352,9 @@ def install_js(app, *args):
         app.add_js_file(_mermaid_js_url)
 
     if app.config.mermaid_init_js:
-        app.add_js_file(None, body=app.config.mermaid_init_js)
+        # If mermaid is local the init-call must be placed after `html_js_files` which has a priority of 800.
+        priority = 500 if _mermaid_js_url is not None else 801
+        app.add_js_file(None, body=app.config.mermaid_init_js, priority=priority)
 
 
 def setup(app):


### PR DESCRIPTION
If the js script is local, the initialization code is inserted before the actual `mermaid.(min.)js` include which makes the init script error with `mermaid is undefined`.
According to: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file
The default prioirty for `app.add_js_file` is 500, while the default priority of `html_js_files` is 800. 

A different solution would be to pass the path to the local mermaid.js to this plugin and have it insert it at the right time but I am not familiar enough with this code base to make that change