### PR TITLE
Split mermaid_cmd to accept npx commands

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -165,8 +165,9 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
 
     with open(tmpfn, 'w') as t:
         t.write(code)
-
-    mm_args = [mermaid_cmd, '-i', tmpfn, '-o', outfn]
+    
+    mermaid_cmd = mermaid_cmd.split(" ")
+    mm_args = [*mermaid_cmd, '-i', tmpfn, '-o', outfn]
     mm_args.extend(self.builder.config.mermaid_params)
     if self.builder.config.mermaid_sequence_config:
        mm_args.extend('--configFile', self.builder.config.mermaid_sequence_config)


### PR DESCRIPTION
Hi, thank you for the nice project.

I was trying not to use mermaid-cli to avoid NPM, but seems like its the easiest route anyways.
While testing I found out we can't call mmdc via npx due to arguments not being split up.

This lets users specify `mermaid_cmd = "npx -y -p @mermaid-js/mermaid-cli mmdc"` in Sphinx conf.py to automatically install mermaid-cli and run mmdc.