### PR TITLE
Make the class diagram generation reproducible

### DIFF
--- a/sphinxcontrib/autoclassdiag.py
+++ b/sphinxcontrib/autoclassdiag.py
@@ -46,7 +46,7 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
 
     return "classDiagram\n" + "\n".join(
             "  %s <|-- %s" % (a, b)
-                for a, b in inheritances
+                for a, b in sorted(inheritances)
             )
 
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that sphinxcontrib-mermaid could not be built reproducibly.

This is because the inheritance properties of class diagrams were collated using a Python `set()` object, and the contents were not sorted when serialised. Another alternative would be to replace the `set()` with a list, but that would have made this patch more invasive (eg. needing to change `.add` to `.append`, etc. etc.)

I originally filed this in Debian as [bug #1012790](https://bugs.debian.org/1012790).