### PR TITLE
Support multi-word mermaid commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Config values
 
 ``mermaid_init_js``
 
-  Mermaid initilizaction code. Default to ``"mermaid.initialize({startOnLoad:true});"``.
+  Mermaid initialization code. Default to ``"mermaid.initialize({startOnLoad:true});"``.
 
 .. versionchanged:: 0.7
     The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,14 @@ Config values
 
 ``mermaid_cmd``
 
-   The command name with which to invoke ``mermaid-cli`` program.  The default is ``'mmdc'``; you may need to set this to a full path if it's not in the executable search path.
+   The command name with which to invoke ``mermaid-cli`` program.
+   The default is ``'mmdc'``; you may need to set this to a full path if it's not in the executable search path.
+   If a string is specified, it is split using `shlex.split` to support multi-word commands.
+   To avoid splitting, a list of strings can be specified.
+   Examples::
+
+      mermaid_cmd = 'npx mmdc'
+      mermeid_cmd = ['npx', '--no-install', 'mmdc']
 
 ``mermaid_cmd_shell``
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -171,8 +171,8 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
         mm_args = shlex.split(mermaid_cmd)
     else:
         mm_args = list(mermaid_cmd)
-    mm_args += ['-i', tmpfn, '-o', outfn]
     mm_args.extend(self.builder.config.mermaid_params)
+    mm_args += ['-i', tmpfn, '-o', outfn]
     if self.builder.config.mermaid_sequence_config:
        mm_args.extend('--configFile', self.builder.config.mermaid_sequence_config)
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -14,6 +14,7 @@ import re
 import codecs
 import posixpath
 import os
+import shlex
 from subprocess import Popen, PIPE
 from hashlib import sha1
 from tempfile import _get_default_tempdir
@@ -166,7 +167,11 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
     with open(tmpfn, 'w') as t:
         t.write(code)
 
-    mm_args = [mermaid_cmd, '-i', tmpfn, '-o', outfn]
+    if isinstance(mermaid_cmd, str):
+        mm_args = shlex.split(mermaid_cmd)
+    else:
+        mm_args = list(mermaid_cmd)
+    mm_args += ['-i', tmpfn, '-o', outfn]
     mm_args.extend(self.builder.config.mermaid_params)
     if self.builder.config.mermaid_sequence_config:
        mm_args.extend('--configFile', self.builder.config.mermaid_sequence_config)


### PR DESCRIPTION
To support words (paths, arguments) containing whitespace,
shell-compatible quotes or a list of strings can be supplied.

This fixes issue #89 in a more robust way than #79.