### PR TITLE
Add support for Python 3.10-3.11, drop EOL 3.6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Sphinxcontrib-mesmaid demo documentation build configuration file, created by
 # sphinx-quickstart on Sun Apr 23 13:10:20 2017.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Documentation',

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     author_email='gaitan@gmail.com',
     description='Mermaid diagrams in yours Sphinx powered docs',
     long_description=long_description(),
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author_email='gaitan@gmail.com',
     description='Mermaid diagrams in yours Sphinx powered docs',
     long_description=long_description(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -49,7 +49,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 import io
 from setuptools import setup, find_packages
 
-readme = io.open('README.rst', encoding="utf-8").read()
-changes = io.open('CHANGELOG.rst', encoding="utf-8").read()
+readme = open('README.rst', encoding="utf-8").read()
+changes = open('CHANGELOG.rst', encoding="utf-8").read()
 version = '0.7.1'
 
 
@@ -26,7 +24,7 @@ def long_description():
     readme_ = remove_block(readme_, ".. autoclasstree::")
     readme_ = remove_block(readme_, ".. autoclasstree::")
     readme_ = remove_block(readme_, ".. versionchanged::")
-    return "{}\n\n{}".format(readme_, changes)
+    return f"{readme_}\n\n{changes}"
 
 
 setup(
@@ -35,7 +33,7 @@ setup(
     url='https://github.com/mgaitan/sphinxcontrib-mermaid',
     download_url='https://pypi.python.org/pypi/sphinxcontrib-mermaid',
     license='BSD',
-    author=u'Martín Gaitán',
+    author='Martín Gaitán',
     author_email='gaitan@gmail.com',
     description='Mermaid diagrams in yours Sphinx powered docs',
     long_description=long_description(),

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     sphinxcontrib
     ~~~~~~~~~~~~~

--- a/sphinxcontrib/autoclassdiag.py
+++ b/sphinxcontrib/autoclassdiag.py
@@ -24,7 +24,7 @@ def get_classes(*cls_or_modules, strict=False):
                 if inspect.isclass(obj_) and (not strict or obj_.__module__.startswith(obj.__name__)):
                     yield obj_
         else:
-            raise MermaidError("%s is not a class nor a module" % cls_or_module)
+            raise MermaidError(f"{cls_or_module} is not a class nor a module")
 
 
 def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
@@ -45,7 +45,7 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
         get_tree(cls)
 
     return "classDiagram\n" + "\n".join(
-            "  {} <|-- {}".format(a, b)
+            f"  {a} <|-- {b}"
                 for a, b in sorted(inheritances)
             )
 

--- a/sphinxcontrib/autoclassdiag.py
+++ b/sphinxcontrib/autoclassdiag.py
@@ -45,7 +45,7 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
         get_tree(cls)
 
     return "classDiagram\n" + "\n".join(
-            "  %s <|-- %s" % (a, b)
+            "  {} <|-- {}".format(a, b)
                 for a, b in sorted(inheritances)
             )
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     sphinx-mermaid
     ~~~~~~~~~~~~~~~
@@ -88,7 +87,7 @@ class Mermaid(Directive):
             try:
                 with codecs.open(filename, 'r', 'utf-8') as fp:
                     mmcode = fp.read()
-            except (IOError, OSError):
+            except OSError:
                 return [document.reporter.warning(
                     'External Mermaid file %r not found or reading '
                     'it failed' % filename, line=self.lineno)]
@@ -151,8 +150,8 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
     mermaid_cmd_shell = self.builder.config.mermaid_cmd_shell in {True, 'True', 'true'}
     hashkey = (code + str(options) + str(self.builder.config.mermaid_sequence_config)).encode('utf-8')
 
-    basename = '%s-%s' % (prefix, sha1(hashkey).hexdigest())
-    fname = '%s.%s' % (basename, _fmt)
+    basename = '{}-{}'.format(prefix, sha1(hashkey).hexdigest())
+    fname = '{}.{}'.format(basename, _fmt)
     relfn = posixpath.join(self.builder.imgpath, fname)
     outdir = os.path.join(self.builder.outdir, self.builder.imagedir)
     outfn = os.path.join(outdir, fname)
@@ -232,8 +231,8 @@ def render_mm_html(self, node, code, options, prefix='mermaid',
             alt = node.get('alt', self.encode(code).strip())
         imgcss = imgcls and 'class="%s"' % imgcls or ''
         if _fmt == 'svg':
-            svgtag = '''<object data="%s" type="image/svg+xml">
-            <p class="warning">%s</p></object>\n''' % (fname, alt)
+            svgtag = '''<object data="{}" type="image/svg+xml">
+            <p class="warning">{}</p></object>\n'''.format(fname, alt)
             self.body.append(svgtag)
         else:
             if 'align' in node:

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -150,8 +150,8 @@ def render_mm(self, code, options, _fmt, prefix='mermaid'):
     mermaid_cmd_shell = self.builder.config.mermaid_cmd_shell in {True, 'True', 'true'}
     hashkey = (code + str(options) + str(self.builder.config.mermaid_sequence_config)).encode('utf-8')
 
-    basename = '{}-{}'.format(prefix, sha1(hashkey).hexdigest())
-    fname = '{}.{}'.format(basename, _fmt)
+    basename = f'{prefix}-{sha1(hashkey).hexdigest()}'
+    fname = f'{basename}.{_fmt}'
     relfn = posixpath.join(self.builder.imgpath, fname)
     outdir = os.path.join(self.builder.outdir, self.builder.imagedir)
     outfn = os.path.join(outdir, fname)
@@ -221,7 +221,7 @@ def render_mm_html(self, node, code, options, prefix='mermaid',
 
         fname, outfn = render_mm(self, code, options, _fmt, prefix)
     except MermaidError as exc:
-        logger.warning('mermaid code %r: ' % code + str(exc))
+        logger.warning(f'mermaid code {code!r}: ' + str(exc))
         raise nodes.SkipNode
 
     if fname is None:
@@ -229,18 +229,18 @@ def render_mm_html(self, node, code, options, prefix='mermaid',
     else:
         if alt is None:
             alt = node.get('alt', self.encode(code).strip())
-        imgcss = imgcls and 'class="%s"' % imgcls or ''
+        imgcss = imgcls and f'class="{imgcls}"' or ''
         if _fmt == 'svg':
-            svgtag = '''<object data="{}" type="image/svg+xml">
-            <p class="warning">{}</p></object>\n'''.format(fname, alt)
+            svgtag = f'''<object data="{fname}" type="image/svg+xml">
+            <p class="warning">{alt}</p></object>
+'''
             self.body.append(svgtag)
         else:
             if 'align' in node:
                 self.body.append('<div align="%s" class="align-%s">' %
                                  (node['align'], node['align']))
 
-            self.body.append('<img src="%s" alt="%s" %s/>\n' %
-                             (fname, alt, imgcss))
+            self.body.append(f'<img src="{fname}" alt="{alt}" {imgcss}/>\n')
             if 'align' in node:
                 self.body.append('</div>\n')
 
@@ -255,7 +255,7 @@ def render_mm_latex(self, node, code, options, prefix='mermaid'):
     try:
         fname, outfn = render_mm(self, code, options, 'pdf', prefix)
     except MermaidError as exc:
-        logger.warning('mm code %r: ' % code + str(exc))
+        logger.warning(f'mm code {code!r}: ' + str(exc))
         raise nodes.SkipNode
 
     if self.builder.config.mermaid_pdfcrop != '':
@@ -265,7 +265,7 @@ def render_mm_latex(self, node, code, options, prefix='mermaid'):
         except OSError as err:
             if err.errno != ENOENT:   # No such file or directory
                 raise
-            logger.warning('command %r cannot be run (needed to crop pdf), check the mermaid_cmd setting' % self.builder.config.mermaid_pdfcrop)
+            logger.warning(f'command {self.builder.config.mermaid_pdfcrop!r} cannot be run (needed to crop pdf), check the mermaid_cmd setting')
             return None, None
 
         stdout, stderr = p.communicate()
@@ -312,7 +312,7 @@ def render_mm_texinfo(self, node, code, options, prefix='mermaid'):
     try:
         fname, outfn = render_mm(self, code, options, 'png', prefix)
     except MermaidError as exc:
-        logger.warning('mm code %r: ' % code + str(exc))
+        logger.warning(f'mm code {code!r}: ' + str(exc))
         raise nodes.SkipNode
     if fname is not None:
         self.body.append('@image{%s,,,[mermaid],png}\n' % fname[:-4])


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Python 3.6 is EOL since last year:

| cycle |  release   | latest | latest release |    eol     |
|:------|:----------:|:-------|:--------------:|:----------:|
| 3.11  | 2022-10-24 | 3.11.0 |   2022-10-24   | 2027-10-24 |
| 3.10  | 2021-10-04 | 3.10.8 |   2022-10-11   | 2026-10-04 |
| 3.9   | 2020-10-05 | 3.9.15 |   2022-10-11   | 2025-10-05 |
| 3.8   | 2019-10-14 | 3.8.15 |   2022-10-11   | 2024-10-14 |
| 3.7   | 2018-06-26 | 3.7.15 |   2022-10-10   | 2023-06-27 |
| 3.6   | 2016-12-22 | 3.6.15 |   2021-09-03   | 2021-12-23 |

Python 3.6 is also little used. Here's the pip installs for sphinxcontrib-mermaid from PyPI for October 2022:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.9      |  74.67% |   311,366 |
| 3.10     |  10.26% |    42,791 |
| 3.8      |   5.82% |    24,279 |
| 3.7      |   4.38% |    18,269 |
| null     |   4.38% |    18,250 |
| 3.6      |   0.32% |     1,339 |
| 3.11     |   0.15% |       616 |
| 3.5      |   0.02% |        80 |
| 2.7      |   0.01% |        26 |
| Total    |         |   417,016 |

Source: `pip install -U pypistats && pypistats python_minor sphinxcontrib-mermaid --last-month`
