### PR TITLE
Only install mermaid.js where needed

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -8,6 +8,7 @@
     :copyright: Copyright 2016-2021 by Martín Gaitán and others, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from __future__ import annotations
 
 import codecs
 import os
@@ -21,6 +22,7 @@ import sphinx
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
+from sphinx.application import Sphinx
 from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
@@ -340,10 +342,20 @@ def man_visit_mermaid(self, node):
     raise nodes.SkipNode
 
 
-def install_js(app, *args):
-    # add required javascript
+def install_js(
+    app: Sphinx,
+    pagename,
+    templatename: str,
+    context: dict,
+    doctree: nodes.document | None,
+) -> None:
+    # Skip for pages without Mermaid diagrams
+    if doctree and not doctree.next_node(mermaid):
+        return
+
+    # Add required JavaScript
     if not app.config.mermaid_version:
-        _mermaid_js_url = None     # asummed is local
+        _mermaid_js_url = None  # assume it is local
     elif app.config.mermaid_version == "latest":
         _mermaid_js_url = f"https://unpkg.com/mermaid/dist/mermaid.min.js"
     else:

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -9,24 +9,25 @@
     :license: BSD, see LICENSE for details.
 """
 
-import re
 import codecs
-import posixpath
 import os
-from subprocess import Popen, PIPE
+import posixpath
+import re
 from hashlib import sha1
+from subprocess import PIPE, Popen
 from tempfile import _get_default_tempdir
+
+import sphinx
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
-
-import sphinx
 from sphinx.locale import _
+from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir
-from sphinx.util import logging
-from .exceptions import MermaidError
+
 from .autoclassdiag import class_diagram
+from .exceptions import MermaidError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes https://github.com/mgaitan/sphinxcontrib-mermaid/issues/80.

Only add the Mermaid JavaScript file when there's a Mermaid diagram on the page.

This avoids loading the JS when needed. Especially useful when you might only have Mermaid digram on one or a few pages. The file is currently 899 kB, with 241 kB transferred over then network (zipped).

Google's [PageSpeed Insights](https://pagespeed.web.dev/report?url=https%3A%2F%2Fhugovk-devguide.readthedocs.io%2Fen%2Flatest%2F) identifies this as a good place to make pages load faster:

<img width="866" alt="image" src="https://user-images.githubusercontent.com/1324225/208301754-fcce6bc8-2f38-4594-bc04-d38fd7d7b04b.png">


Based on https://github.com/kedro-org/kedro/pull/1392, it's better to handle it here than in end user projects, and also simpler.

---

Also sort imports using isort:

```sh
pip install isort
isort sphinxcontrib/mermaid.py
```