### PR TITLE
Support ESM initialization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+   "python.testing.pytestArgs": [
+      "tests"
+   ],
+   "python.testing.unittestEnabled": false,
+   "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-   "python.testing.pytestArgs": [
-      "tests"
-   ],
-   "python.testing.unittestEnabled": false,
-   "python.testing.pytestEnabled": true
-}

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,10 @@ Config values
 
 ``mermaid_version``
 
-  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on https://unpkg.com/browse/mermaid/.  The default is ``"9.4.0"``. If you need a newer version, you'll need to add the custom initialization. See below. 
+  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on <https://cdn.jsdelivr.net/npm/mermaid@latest/>_.
+  
+  .. note::
+    The package defaults to the latest available version on the CDN.
 
   If it's set to ``""``, the lib won't be automatically included from the CDN service and you'll need to add it as a local
   file in ``html_js_files``. For instance, if you download the lib to `_static/js/mermaid.js`, in ``conf.py``::
@@ -133,7 +136,7 @@ Config values
 
 ``mermaid_init_js``
 
-  Mermaid initilizaction code. Default to ``"mermaid.initialize({startOnLoad:true});"``.
+  Mermaid initialization code. Default to ``"mermaid.initialize({startOnLoad:true});"``.
 
 .. versionchanged:: 0.7
     The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Config values
 
 ``mermaid_version``
 
-  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on <https://cdn.jsdelivr.net/npm/mermaid@latest/>_.
+  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on https://cdn.jsdelivr.net/npm/mermaid.
   
   .. note::
     The package defaults to the latest available version on the CDN.

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,25 @@ Config values
 .. versionchanged:: 0.7
     The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.
 
+``mermaid_securitylevel``
+
+  Sets the `securityLevel <https://mermaid.js.org/config/usage.html#securitylevel>`_ for Mermaid when installed from the CDN.
+
+``mermaid_theme``
+
+  Sets the site-wide `theme <https://mermaid.js.org/config/theming.html#available-themes>`_ for Mermaid when installed from the CDN.
+
+``mermaid_loglevel``
+
+  Sets the global log level for Mermaid when installed from the CDN.
+
+``mermaid_fontfamily``
+
+  Sets the font family used in Mermaid diagrams. You can provide a list as a single string, e.g. ``"'trebuchet ms', verdana, arial, sans-serif;"``.
+
+``mermaid_arrowmarkerabsolute``
+
+  Controls whether or arrow markers in html code are absolute paths or anchor
 
 ``mermaid_cmd``
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -31,6 +31,7 @@ from sphinx.util.osutil import ensuredir
 
 from .autoclassdiag import class_diagram
 from .exceptions import MermaidError
+from .mermaidconfig import Config
 
 logger = logging.getLogger(__name__)
 
@@ -408,7 +409,10 @@ def install_js(
     else:
         _mermaid_js_url = f"https://cdn.jsdelivr.net/npm/mermaid@{app.config.mermaid_version}/dist/mermaid.esm.min.mjs"
     if _mermaid_js_url:
-        app.add_js_file(None, type="module", body=f"import mermaid from \"{_mermaid_js_url}\";", priority=app.config.mermaid_js_priority)
+        mermaid_config = Config(True, app.config.mermaid_theme, app.config.mermaid_fontfamily, app.config.mermaid_securitylevel, app.config.mermaid_loglevel, app.config.mermaid_arrowmarkerabsolute)
+        mermaid_conf = mermaid_config.toJSON()
+        app.add_js_file(None, body=f"const mermaidConfig = {mermaid_conf}")
+        app.add_js_file(None, type="module", body=f"import mermaid from \"{_mermaid_js_url}\"; mermaid.initialize(mermaidConfig)", priority=app.config.mermaid_js_priority)
 
     if app.config.mermaid_init_js:
         # If mermaid is local the init-call must be placed after `html_js_files` which has a priority of 800.
@@ -443,10 +447,15 @@ def setup(app):
     # So the current latest version supported is this
     # Discussion: https://github.com/mermaid-js/mermaid/discussions/4148
     app.add_config_value("mermaid_version", "latest", "html")
+    app.add_config_value("mermaid_theme", "default", "html")
+    app.add_config_value("mermaid_securitylevel", "strict", "html")
+    app.add_config_value("mermaid_loglevel", "fatal", "html")
+    app.add_config_value("mermaid_fontfamily", "'trebuchet ms', verdana, arial, sans-serif;", "html")
+    app.add_config_value("mermaid_arrowmarkerabsolute", False, "html")
     app.add_config_value("mermaid_js_priority", 500, "html")
     app.add_config_value("mermaid_init_js_priority", 500, "html")
     app.add_config_value(
-        "mermaid_init_js", "mermaid.initialize({startOnLoad:true});", "html"
+        "mermaid_init_js", "", "html"
     )
     app.connect("html-page-context", install_js)
 

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -404,11 +404,11 @@ def install_js(
     if not app.config.mermaid_version:
         _mermaid_js_url = None  # assume it is local
     elif app.config.mermaid_version == "latest":
-        _mermaid_js_url = "https://unpkg.com/mermaid/dist/mermaid.min.js"
+        _mermaid_js_url = "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"
     else:
-        _mermaid_js_url = f"https://unpkg.com/mermaid@{app.config.mermaid_version}/dist/mermaid.min.js"
+        _mermaid_js_url = f"https://cdn.jsdelivr.net/npm/mermaid@{app.config.mermaid_version}/dist/mermaid.esm.min.mjs"
     if _mermaid_js_url:
-        app.add_js_file(_mermaid_js_url, priority=app.config.mermaid_js_priority)
+        app.add_js_file(None, type="module", body=f"import mermaid from \"{_mermaid_js_url}\";", priority=app.config.mermaid_js_priority)
 
     if app.config.mermaid_init_js:
         # If mermaid is local the init-call must be placed after `html_js_files` which has a priority of 800.
@@ -442,7 +442,7 @@ def setup(app):
     # thus it requires a different initialization code not yet supported. 
     # So the current latest version supported is this
     # Discussion: https://github.com/mermaid-js/mermaid/discussions/4148
-    app.add_config_value("mermaid_version", "9.4.0", "html")
+    app.add_config_value("mermaid_version", "latest", "html")
     app.add_config_value("mermaid_js_priority", 500, "html")
     app.add_config_value("mermaid_init_js_priority", 500, "html")
     app.add_config_value(

--- a/sphinxcontrib/mermaidconfig.py
+++ b/sphinxcontrib/mermaidconfig.py
@@ -1,0 +1,14 @@
+import json
+
+class Config:
+   def __init__ (self, startonload=True, theme="default", fontfamily="'trebuchet ms', verdana, arial, sans-serif;", securitylevel="strict", loglevel="fatal", arrowmarkerabsolute=False):
+      self.startOnLoad = startonload
+      self.theme = theme
+      self.fontFamily = fontfamily
+      self.securityLevel = securitylevel
+      self.logLevel = loglevel
+      self.arrowMarkerAbsolute = arrowmarkerabsolute
+   
+   def toJSON(self):
+        return json.dumps(self, default=lambda o: o.__dict__, 
+            sort_keys=True, indent=4)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -14,6 +14,7 @@ def index(app, build_all):
 @pytest.mark.sphinx('html', testroot="basic")
 def test_html_raw(index):
     assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";</script>' in index
+    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
     assert """<div class="mermaid">
             sequenceDiagram
    participant Alice

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -10,11 +10,18 @@ def index(app, build_all):
     # normalize script tag for compat to Sphinx<4
     return (app.outdir / 'index.html').read_text().replace("<script >", "<script>")
 
-
+# Test CDN load
 @pytest.mark.sphinx('html', testroot="basic")
 def test_html_raw(index):
-    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";</script>' in index
-    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
     assert """<div class="mermaid">
             sequenceDiagram
    participant Alice
@@ -22,29 +29,109 @@ def test_html_raw(index):
    Alice-&gt;John: Hello John, how are you?
         </div>""" in index
 
-
+# Test specific version
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_version': '8.3'})
 def test_conf_mermaid_version(app, index):
     assert app.config.mermaid_version == "8.3"
-    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@8.3/dist/mermaid.esm.min.mjs";</script>' in index
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@8.3/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
 
-
+# Test loading local Mermaid
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_version': None})
 def test_conf_mermaid_no_version(app, index):
     # requires local mermaid
     assert 'mermaid.min.js' not in index
 
-
+# Test custom init script
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_init_js': "custom script;"})
 def test_mermaid_init_js(index):
     assert "<script>mermaid.initialize({startOnLoad:true});</script>" not in index
     assert '<script>custom script;</script>' in index
 
+# Test theme override
+@pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_theme': "forest"})
+def test_mermaid_theme(index):
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "forest"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
 
+# Test font family override
+@pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_fontfamily': "comic sans"})
+def test_mermaid_theme(index):
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "comic sans",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
+
+# Test log level override
+@pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_loglevel': "info"})
+def test_mermaid_loglevel(index):
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "info",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
+
+# Test security level override
+@pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_securitylevel': "loose"})
+def test_mermaid_securitylevel(index):
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "loose",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
+
+# Test arrow marker absolute override
+@pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_arrowmarkerabsolute': True})
+def test_mermaid_arrowmarkerabsolute(index):
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": true,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
+
+# Test Markdown rendering
 @pytest.mark.sphinx('html', testroot="markdown")
 def test_html_raw_from_markdown(index):
-    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";</script>' in index
-    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
+    assert """<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs"; mermaid.initialize(mermaidConfig)</script>""" in index
+    assert """const mermaidConfig = {
+    "arrowMarkerAbsolute": false,
+    "fontFamily": "'trebuchet ms', verdana, arial, sans-serif;",
+    "logLevel": "fatal",
+    "securityLevel": "strict",
+    "startOnLoad": true,
+    "theme": "default"
+}""" in index
     assert """
 <div class="mermaid">
                 sequenceDiagram

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -13,8 +13,7 @@ def index(app, build_all):
 
 @pytest.mark.sphinx('html', testroot="basic")
 def test_html_raw(index):
-    assert '<script src="https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"></script>' in index
-    assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
+    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";</script>' in index
     assert """<div class="mermaid">
             sequenceDiagram
    participant Alice
@@ -26,7 +25,7 @@ def test_html_raw(index):
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_version': '8.3'})
 def test_conf_mermaid_version(app, index):
     assert app.config.mermaid_version == "8.3"
-    assert '<script src="https://unpkg.com/mermaid@8.3/dist/mermaid.min.js"></script>' in index
+    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@8.3/dist/mermaid.esm.min.mjs";</script>' in index
 
 
 @pytest.mark.sphinx('html', testroot="basic", confoverrides={'mermaid_version': None})
@@ -43,7 +42,7 @@ def test_mermaid_init_js(index):
 
 @pytest.mark.sphinx('html', testroot="markdown")
 def test_html_raw_from_markdown(index):
-    assert '<script src="https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"></script>' in index
+    assert '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@latest/dist/mermaid.esm.min.mjs";</script>' in index
     assert "<script>mermaid.initialize({startOnLoad:true});</script>" in index
     assert """
 <div class="mermaid">


### PR DESCRIPTION
This MR adds support for initializing Mermaid as a module from the new CDN. It also provides a new `Config` object which can be used to override the following global settings:

1. Theme
2. Font family
3. Security level
4. Log level
5. Whether arrow markers are treated as absolute

This MR contains:

- [x] Documentation
- [x] Tests