### PR TITLE
Do not fail on empty class diagram generation

### DIFF
--- a/sphinxcontrib/autoclassdiag.py
+++ b/sphinxcontrib/autoclassdiag.py
@@ -48,6 +48,9 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
     for cls in get_classes(*cls_or_modules, strict=strict):
         get_tree(cls)
 
+    if not inheritances:
+        return ""
+
     return "classDiagram\n" + "\n".join(
         f"  {a} <|-- {b}" for a, b in sorted(inheritances)
     )

--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -106,18 +106,27 @@ class Mermaid(Directive):
         else:
             # inline mermaid code
             mmcode = "\n".join(self.content)
-            if not mmcode.strip():
-                return [
-                    self.state_machine.reporter.warning(
-                        'Ignoring "mermaid" directive without content.',
-                        line=self.lineno,
-                    )
-                ]
         return mmcode
 
     def run(self):
+        mmcode = self.get_mm_code()
+        # mmcode is a list, so it's a system message, not content to be included in the
+        # document.
+        if not isinstance(mmcode, str):
+            return mmcode
+
+        # if mmcode is empty, ignore the directive.
+        if not mmcode.strip():
+            return [
+                self.state_machine.reporter.warning(
+                    'Ignoring "mermaid" directive without content.',
+                    line=self.lineno,
+                )
+            ]
+
+        # Wrap the mermaid code into a code node.
         node = mermaid()
-        node["code"] = self.get_mm_code()
+        node["code"] = mmcode
         node["options"] = {}
         if "alt" in self.options:
             node["alt"] = self.options["alt"]

--- a/tests/roots/test-basic/index.rst
+++ b/tests/roots/test-basic/index.rst
@@ -7,3 +7,10 @@ Hi, basic test
       participant Alice
       participant Bob
       Alice->John: Hello John, how are you?
+
+Empty class diagram should not fail
+-----------------------------------
+
+.. mermaid::
+
+   classDiagram

--- a/tests/roots/test-markdown/index.md
+++ b/tests/roots/test-markdown/index.md
@@ -7,3 +7,10 @@
       participant Bob
       Alice->John: Hello John, how are you?
 ```
+
+# Empty class diagram should not fail
+
+```{mermaid}
+
+    classDiagram
+```


### PR DESCRIPTION
> Note: this is a follow up of #112 which was inadvertently closed during GitHub fork syncing.

The `class_diagram()` method is allow to generate the following Mermaid code if it is used on a module that has no class in it:
```
classDiagram

```

When this is parsed and rendered by Mermaid itself, it fails:
<img width="480" alt="Screenshot 2023-03-05 at 11 47 01" src="https://user-images.githubusercontent.com/159718/222948462-45c08c28-3a6d-4eb9-9442-85659f4aa121.png">

This PR fix that by not producing an empty `classDiagram` graph, and checking any Mermaid directives fed to the plugin is not empty.

It has the nice side effect of also producing a warning in Sphinx log (`WARNING: Ignoring "mermaid" directive without content.`) on any empty `mermaid` directives, including those sourced from a file.