### PR TITLE
Replaced div for pre when rendering raw to avoid newline issue

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -229,14 +229,14 @@ def _render_mm_html_raw(
     self, node, code, options, prefix="mermaid", imgcls=None, alt=None
 ):
     if "align" in node:
-        tag_template = """<div align="{align}" class="mermaid align-{align}">
+        tag_template = """<pre align="{align}" class="mermaid align-{align}">
             {code}
-        </div>
+        </pre>
         """
     else:
-        tag_template = """<div class="mermaid">
+        tag_template = """<pre class="mermaid">
             {code}
-        </div>"""
+        </pre>"""
 
     self.body.append(
         tag_template.format(align=node.get("align"), code=self.encode(code))


### PR DESCRIPTION
I couldn't get the project working with sphinx/rst, only the graph type worked.

After switching the html node type to "pre" it finally worked for all graph types.