### PR TITLE
Fixes libasound2 error message

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,8 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04
+  apt_packages:
+    - libasound2
   tools:
     python: "3.8"
     nodejs: "16"

--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,8 @@ In order to have Mermaid diagrams build properly in PDFs generated on readthedoc
     # Set the version of Python and other tools you might need
     build:
       os: ubuntu-20.04
+      apt_packages:
+        - libasound2
       tools:
         python: "3.8"
         nodejs: "16"


### PR DESCRIPTION
When compiling on readthedocs, you might want to install `libasound2` to prevent this error message.

b'\nError: Failed to launch the browser process!\n/home/docs/.cache/puppeteer/chrome/linux-1108766/chrome-linux/chrome: error while loading shared libraries: libasound.so.2: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n\n    at Interface.onClose (file:///home/docs/.asdf/installs/nodejs/16.18.1/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/@puppeteer/browsers/lib/esm/launch.js:253:24)\n    at Interface.emit (node:events:525:35)\n    at Interface.close (node:readline:590:8)\n    at Socket.onend (node:readline:280:10)\n    at Socket.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams/readable:1358:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)\n\n'
