### PR TITLE
Use an <img> for SVG output instead of an <object>

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -285,20 +285,14 @@ def render_mm_html(self, node, code, options, prefix="mermaid", imgcls=None, alt
         if alt is None:
             alt = node.get("alt", self.encode(code).strip())
         imgcss = imgcls and f'class="{imgcls}"' or ""
-        if _fmt == "svg":
-            svgtag = f"""<object data="{fname}" type="image/svg+xml">
-            <p class="warning">{alt}</p></object>
-"""
-            self.body.append(svgtag)
-        else:
-            if "align" in node:
-                self.body.append(
-                    '<div align="%s" class="align-%s">' % (node["align"], node["align"])
-                )
+        if "align" in node:
+            self.body.append(
+                '<div align="%s" class="align-%s">' % (node["align"], node["align"])
+            )
 
-            self.body.append(f'<img src="{fname}" alt="{alt}" {imgcss}/>\n')
-            if "align" in node:
-                self.body.append("</div>\n")
+        self.body.append(f'<img src="{fname}" alt="{alt}" {imgcss}/>\n')
+        if "align" in node:
+            self.body.append("</div>\n")
 
     raise nodes.SkipNode
 


### PR DESCRIPTION
`<img>`, unlike `<object>`, has proper alt text support (i.e. that's not just fallback content) and is easily saved, opened in a new tab, etc. from the page where it appears.

This does mean the SVG's DOM will no longer be available for inspection by JavaScript in the containing document (e.g. `object.contentDocument`), but I don't think that was intended to be a feature of SVG output for this Sphinx extension.

Resolves <https://github.com/mgaitan/sphinxcontrib-mermaid/issues/102> as well.