### PR TITLE
Fix encoding of tmp input file

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -195,7 +195,7 @@ def render_mm(self, code, options, _fmt, prefix="mermaid"):
 
     ensuredir(os.path.dirname(outfn))
 
-    with open(tmpfn, "w") as t:
+    with open(tmpfn, "w", encoding="utf-8") as t:
         t.write(code)
 
     if isinstance(mermaid_cmd, str):


### PR DESCRIPTION
When invoking `make latex` in a sphinx project, a parsing error may be raised from mermaid.js due to incorrect encoding of temporary file `tmpfn`. This issue can be reproduced when mermaid diagram contains non-ASCII text (such as Chinese).

This PR avoids this kind of parsing error by specifying file encoding as UTF-8 when writing stuff to `tmpfn`.