### PR TITLE
Pass current envvars into Popen when triggering diagram generation

### DIFF
--- a/sphinxcontrib/mermaid.py
+++ b/sphinxcontrib/mermaid.py
@@ -209,9 +209,7 @@ def render_mm(self, code, options, _fmt, prefix="mermaid"):
         mm_args.extend("--configFile", self.builder.config.mermaid_sequence_config)
 
     try:
-        p = Popen(
-            mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE
-        )
+        p = Popen(mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE, env=os.environ)
     except FileNotFoundError:
         logger.warning(
             "command %r cannot be run (needed for mermaid "


### PR DESCRIPTION
    This allows the command to work in environments using tools like asdf to maintain ie node dependencies
    
   
   
Longer explanation:

So far I had an environment prepared within a docker image to generate documentation. 
However recently I was testing the feasibility to move it out of the docker definition into an easier cache'able (on CI) regular environment definition. Meaning that instead of dockerfile, I'd have Pipfile and node-modules required at the project's documentation level.
Since I also produce the documentation for confluence, I needed to generate svg's.
And because I try to separate component's virtualenv's to be able to update dependencies independently (also if a component requires node) I started using asdf-vm for that.
In order for mermaid to generate svg files through sphinxcontrib-mermaid, I had to pass environment variables, otherwise I got errors that `npx mmdc` command was not found.
Passing environmental variables fixes that issue, and allows to get the diagrams generated, at least in the case of `mermaid_cmd_shell=False` setting. `mermaid_cmd_shell=True` triggers the `npx mmdc` command without any issue, however the diagrams are not generated at all.

I've tested this on mermaid's own documentation with conf.py settings like that:

``` python
mermaid_output_format = 'svg'
mermaid_cmd = "npx mmdc"
mermaid_params = ['-p', 'puppeteer-config.json']
```