### PR TITLE
Add python v3.13 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.9", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.9", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -21,8 +21,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
-          cache-dependency-path: setup.py
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.rst"
 license = { text = "BSD" }
 version = "0.9.2"
 requires-python = ">=3.9"
-keywords = []
+keywords = ["sphinx", "mermaid", "diagrams", "documentation"]
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -23,11 +23,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Documentation",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
Next week Python 3.13 is released and Pythonm3.8 goes EOL.
* https://peps.python.org/pep-0719/#release-schedule