### PR TITLE
`setup.py` is replaced by `pyproject.toml`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ Markdown support
 ----------------
 
 You can include Mermaid diagrams in your Markdown documents in Sphinx.
-You just need to setup the `markdown support in Sphinx <https://www.sphinx-doc.org/en/master/usage/markdown.html>`_ via
+You just need to set up the `markdown support in Sphinx <https://www.sphinx-doc.org/en/master/usage/markdown.html>`_ via
 `myst-parser <https://myst-parser.readthedocs.io/>`_
 . See a `minimal configuration from the tests <https://github.com/mgaitan/sphinxcontrib-mermaid/blob/master/tests/roots/test-markdown/conf.py>`_
 

--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,0 @@
-__import__("setuptools").setup()


### PR DESCRIPTION
https://packaging.python.org/en/latest/discussions/setup-py-deprecated

In `README.rst`, ___setup___ is a noun while ___set up___ is a verb.

In the removed `setup.py`...
> Direct use of [`__import__()`](https://docs.python.org/3/library/functions.html#import__) is also discouraged in favor of [importlib.import_module()](https://docs.python.org/3/library/importlib.html#importlib.import_module).
* [`https://docs.python.org/3/library/functions.html#import__`](https://docs.python.org/3/library/functions.html#import__)