### PR TITLE
Add import shim for sphinx ExtensionError

### DIFF
--- a/sphinxcontrib/mermaid/autoclassdiag.py
+++ b/sphinxcontrib/mermaid/autoclassdiag.py
@@ -1,7 +1,7 @@
 import inspect
 
 from sphinx.errors import ExtensionError
-from sphinx.util import  import_object
+from sphinx.util import import_object
 
 from .exceptions import MermaidError
 

--- a/sphinxcontrib/mermaid/autoclassdiag.py
+++ b/sphinxcontrib/mermaid/autoclassdiag.py
@@ -1,9 +1,6 @@
 import inspect
 
-try:
-    from sphinx.errors import ExtensionError
-except ImportError:
-    from sphinx.util import ExtensionError
+from sphinx.errors import ExtensionError
 from sphinx.util import  import_object
 
 from .exceptions import MermaidError

--- a/sphinxcontrib/mermaid/autoclassdiag.py
+++ b/sphinxcontrib/mermaid/autoclassdiag.py
@@ -1,6 +1,10 @@
 import inspect
 
-from sphinx.util import ExtensionError, import_object
+try:
+    from sphinx.errors import ExtensionError
+except ImportError:
+    from sphinx.util import ExtensionError
+from sphinx.util import  import_object
 
 from .exceptions import MermaidError
 


### PR DESCRIPTION
It looks like with `sphinx==8.1.0` the `ExtensionError` is no longer available in `sphinx.util` and should be imported from `sphinx.errors`.

~This PR tries `sphinx.errors.ExtensionError` first and falls back to `sphinx.util.ExtensionError` for backward compatibility.~

Fixes #160 