### PR TITLE
separate import, elk layout and init-js into different sub category

### DIFF
--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -464,15 +464,16 @@ def install_js(
     if _mermaid_elk_js_url:
         app.add_js_file(_mermaid_elk_js_url, priority=app.config.mermaid_js_priority, type="module")
 
-    if app.config.mermaid_init_js == _MERMAID_INIT_JS_DEFAULT:
-        # Update if esm is used and no custom init-js is provided
-        if _mermaid_elk_js_url:
-            # Add registration of ELK layouts
-            app.config.mermaid_init_js = f'import mermaid from "{_mermaid_js_url}";import elkLayouts from "{_mermaid_elk_js_url}";mermaid.registerLayoutLoaders(elkLayouts);{app.config.mermaid_init_js}'
-        else:
-            app.config.mermaid_init_js = f'import mermaid from "{_mermaid_js_url}";{app.config.mermaid_init_js}'
+    if _mermaid_elk_js_url:
+        # Add registration of ELK layouts
+        app.config.mermaid_init_js = f'import elkLayouts from "{_mermaid_elk_js_url}";mermaid.registerLayoutLoaders(elkLayouts);{app.config.mermaid_init_js}'
+
 
     if app.config.mermaid_init_js:
+
+        # Add the mermaid import from link to the init-js
+        app.config.mermaid_init_js = f'import mermaid from "{_mermaid_js_url}";{app.config.mermaid_init_js}'
+        
         # If mermaid is local the init-call must be placed after `html_js_files` which has a priority of 800.
         priority = app.config.mermaid_init_js_priority if _mermaid_js_url is not None else 801
         app.add_js_file(None, body=app.config.mermaid_init_js, priority=priority, type="module")


### PR DESCRIPTION
I do think it need some quick discussion about how to treat the init-js behavior. As stated in #172, documentation may lake some information about the behavior of init-js. I do think that init-js config variable shouldn't be linked with mermaid version and elk import and following this I propose this code modification to separate these three behavior.