### PR TITLE
Fix markup typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ Directive options
 
 ``:caption:``: can be used to give a caption to the diagram.
 
-``:zoom:``: can be used to enable zooming the diagram. For a global config see ``mermaid_d3_zoom``` bellow. 
+``:zoom:``: can be used to enable zooming the diagram. For a global config see ``mermaid_d3_zoom`` bellow. 
 
 .. figure:: https://user-images.githubusercontent.com/16781833/228022911-c26d1e01-7f71-4ab7-bb33-ce53056f8343.gif
    :align: center


### PR DESCRIPTION
Thank you for creating and maintaining this awesome Sphinx extension.

I found a small typo (trailing backtick) and am submitting this pull request to fix it.

<img width="953" height="71" alt="image" src="https://github.com/user-attachments/assets/f01daaab-1b9d-4bb9-b245-142ff5825e7b" />
