### PR TITLE
Add opacity configuration for fullscreen button

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,10 @@ Config values
     Customizes the fullscreen button icon/text. Default is ``"⛶"``. You can use any Unicode character
     or emoji, for example ``"🔍"`` or ``"⛶"``.
 
+``mermaid_fullscreen_button_opacity``
+
+    Customizes the fullscreen button opacity, to avoid fully obscuring important chart content.
+    Default is ``50`` (percent). You can use any value from 0 to 100. Button becomes fully opaque on hover.
 
 Markdown support
 ----------------

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -525,6 +525,7 @@ def install_js(
     # Handle fullscreen feature
     if _has_fullscreen and not _wrote_mermaid_run:
         _button_text = app.config.mermaid_fullscreen_button
+        _button_opacity = app.config.mermaid_fullscreen_button_opacity
         if _has_zoom:
             # Fullscreen with zoom
             _d3_selector = ".mermaid svg" if app.config.mermaid_d3_zoom else ""
@@ -549,6 +550,7 @@ def install_js(
                 mermaid_js_url=_mermaid_js_url,
                 fullscreen_css=_FULLSCREEN_CSS,
                 button_text=_button_text,
+                button_opacity=_button_opacity,
                 d3_selector=_d3_selector if _d3_selector else ".mermaid svg",
                 d3_node_count=count if _d3_selector else -1,
             )
@@ -600,6 +602,7 @@ def setup(app):
     app.add_config_value("mermaid_d3_zoom", False, "html")
     app.add_config_value("mermaid_fullscreen", True, "html")
     app.add_config_value("mermaid_fullscreen_button", "⛶", "html")
+    app.add_config_value("mermaid_fullscreen_button_opacity", "50", "html")
     app.connect("html-page-context", install_js)
 
     return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinxcontrib/mermaid/fullscreen.css
+++ b/sphinxcontrib/mermaid/fullscreen.css
@@ -25,6 +25,7 @@
 }
 
 .mermaid-fullscreen-btn:hover {
+    opacity: 100% !important;
     background: rgba(255, 255, 255, 1);
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
     transform: scale(1.1);

--- a/sphinxcontrib/mermaid/fullscreen_zoom.js
+++ b/sphinxcontrib/mermaid/fullscreen_zoom.js
@@ -96,6 +96,7 @@ const load = async () => {{
         fullscreenBtn.className = 'mermaid-fullscreen-btn' + (darkTheme ? ' dark-theme' : '');
         fullscreenBtn.setAttribute('aria-label', 'View diagram in fullscreen');
         fullscreenBtn.textContent = '{button_text}';
+        fullscreenBtn.style.opacity = '{button_opacity}%';
 
         // Calculate dynamic position based on diagram's margin and padding
         const diagramStyle = window.getComputedStyle(mermaidDiv);


### PR DESCRIPTION
For https://github.com/mgaitan/sphinxcontrib-mermaid/issues/191 I noticed the top parts of the diagram were covered by the fullscreen button. By allowing customization of the opacity, I think we can have the best of both worlds.

Fixes #193 

![tmp](https://github.com/user-attachments/assets/91a569a9-b5ed-4ebb-ae13-8c350f348598)
