### PR TITLE
Normalize div class for fullscreen image

### DIFF
--- a/sphinxcontrib/mermaid/fullscreen.css
+++ b/sphinxcontrib/mermaid/fullscreen.css
@@ -65,7 +65,7 @@
     justify-content: center;
 }
 
-.mermaid-fullscreen-content {
+.mermaid-container-fullscreen {
     position: relative;
     width: 95vw;
     height: 90vh;
@@ -81,12 +81,12 @@
     justify-content: center;
 }
 
-.mermaid-fullscreen-content.dark-theme {
+.mermaid-container-fullscreen.dark-theme {
     background: #1a1a1a;
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.8);
 }
 
-.mermaid-fullscreen-content .mermaid {
+.mermaid-container-fullscreen .mermaid {
     width: 100%;
     height: 100%;
     display: flex;
@@ -94,7 +94,7 @@
     justify-content: center;
 }
 
-.mermaid-fullscreen-content .mermaid svg {
+.mermaid-container-fullscreen .mermaid svg {
     width: 100%;
     height: auto;
     max-width: 100%;

--- a/sphinxcontrib/mermaid/fullscreen.js
+++ b/sphinxcontrib/mermaid/fullscreen.js
@@ -39,11 +39,11 @@ const initFullscreen = async () => {{
     modal.setAttribute('aria-label', 'Fullscreen diagram viewer');
     modal.innerHTML = `
         <button class="mermaid-fullscreen-close${{darkTheme ? ' dark-theme' : ''}}" aria-label="Close fullscreen">✕</button>
-        <div class="mermaid-fullscreen-content${{darkTheme ? ' dark-theme' : ''}}"></div>
+        <div class="mermaid-container-fullscreen${{darkTheme ? ' dark-theme' : ''}}"></div>
     `;
     document.body.appendChild(modal);
 
-    const modalContent = modal.querySelector('.mermaid-fullscreen-content');
+    const modalContent = modal.querySelector('.mermaid-container-fullscreen');
     const closeBtn = modal.querySelector('.mermaid-fullscreen-close');
 
     const closeModal = () => {{

--- a/sphinxcontrib/mermaid/fullscreen_zoom.js
+++ b/sphinxcontrib/mermaid/fullscreen_zoom.js
@@ -53,11 +53,11 @@ const load = async () => {{
     modal.setAttribute('aria-label', 'Fullscreen diagram viewer');
     modal.innerHTML = `
         <button class="mermaid-fullscreen-close${{darkTheme ? ' dark-theme' : ''}}" aria-label="Close fullscreen">✕</button>
-        <div class="mermaid-fullscreen-content${{darkTheme ? ' dark-theme' : ''}}"></div>
+        <div class="mermaid-container-fullscreen${{darkTheme ? ' dark-theme' : ''}}"></div>
     `;
     document.body.appendChild(modal);
 
-    const modalContent = modal.querySelector('.mermaid-fullscreen-content');
+    const modalContent = modal.querySelector('.mermaid-container-fullscreen');
     const closeBtn = modal.querySelector('.mermaid-fullscreen-close');
 
     let previousScrollOffset = [window.scrollX, window.scrollY];


### PR DESCRIPTION
While implementing a feature for [yardang](https://github.com/python-project-templates/yardang), i noticed a discrepancy between the class names in normal view and fullscreen. This PR normalizes them.