### PR TITLE
Revamp JS initialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 +++++++++++++++++++++
 
 - Drop support for Python 3.8 and 3.9
+- Add support for dynamic theme changes
 
 1.2.3 (November 25, 2025)
 +++++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -149,44 +149,6 @@ Config values
    The output format for Mermaid when building HTML files.  This must be either ``'raw'``
    ``'png'`` or ``'svg'``; the default is ``'raw'``. ``mermaid-cli`` is required if it's not ``raw``
 
-``mermaid_use_local``
-
-   Optional path to a local installation of ``mermaid.esm.min.mjs``. By default, we will pull from jsdelivr.
-
-``mermaid_version``
-
-  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on https://www.jsdelivr.com/package/npm/mermaid.  The default is ``"11.12.1"``.
-
-.. versionchanged:: 0.7
-    The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.
-
-``mermaid_elk_use_local``
-
-   Optional path to a local installation of ``mermaid-layout-elk.esm.min.mjs``. By default, we will pull from jsdelivr.
-
-``mermaid_include_elk``
-
-  The version of mermaid ELK renderer that will be used. The default is ``"0.2.0"``. Leave blank to disable ELK layout.
-
-``d3_use_local``
-
-   Optional path to a local installation of ``d3.min.js``. By default, we will pull from jsdelivr.
-
-``d3_version``
-
-  The version of d3 that will be used to provide zoom functionality on mermaid graphs.  The default is ``"7.9.0"``.
-
-``mermaid_init_js``
-
-  Mermaid initialization code. The Default initialization is set to
-
-    mermaid.initialize({ startOnLoad: true})
-
-
-.. versionchanged:: 0.7
-    The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.
-
-
 ``mermaid_cmd``
 
    The command name with which to invoke ``mermaid-cli`` program.
@@ -225,6 +187,37 @@ Config values
 
     If using latex output, it might be useful to crop the pdf just to the needed space. For this, ``pdfcrop`` can be used.
     State binary name to use this extra function.
+
+``mermaid_init_config``
+
+   Optional override of arguments to ``mermaid.initialize()``, passed in as a JSON. Defaults to ``{ "startOnLoad": True}``.
+
+``mermaid_use_local``
+
+   Optional path to a local installation of ``mermaid.esm.min.mjs``. By default, we will pull from jsdelivr.
+
+``mermaid_version``
+
+  The version of mermaid that will be used to parse ``raw`` output in HTML files. This should match a version available on https://www.jsdelivr.com/package/npm/mermaid.  The default is ``"11.12.1"``.
+
+.. versionchanged:: 0.7
+    The init code doesn't include the `<script>` tag anymore. It's automatically added at build time.
+
+``mermaid_elk_use_local``
+
+   Optional path to a local installation of ``mermaid-layout-elk.esm.min.mjs``. By default, we will pull from jsdelivr.
+
+``mermaid_include_elk``
+
+  The version of mermaid ELK renderer that will be used. The default is ``"0.2.0"``. Leave blank to disable ELK layout.
+
+``d3_use_local``
+
+   Optional path to a local installation of ``d3.min.js``. By default, we will pull from jsdelivr.
+
+``d3_version``
+
+  The version of d3 that will be used to provide zoom functionality on mermaid graphs.  The default is ``"7.9.0"``.
 
 ``mermaid_d3_zoom``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description="Mermaid diagrams in yours Sphinx powered docs"
 readme = "docs/readme_pypa.md"
 license = { text = "BSD" }
 version = "1.2.3"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["sphinx", "mermaid", "diagrams", "documentation"]
 
 classifiers = [
@@ -33,6 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "jinja2",
     "sphinx",
     "pyyaml",
 ]

--- a/sphinxcontrib/mermaid/default.css.j2
+++ b/sphinxcontrib/mermaid/default.css.j2
@@ -1,12 +1,12 @@
-pre.mermaid {{
+pre.mermaid {
     /* Same as .mermaid-container > pre */
     display: block;
-    width: {mermaid_width};
-}}
+    width: {{ mermaid_width }};
+}
 
-pre.mermaid > svg {{
+pre.mermaid > svg {
     /* Same as .mermaid-container > pre > svg */
-    height: {mermaid_height};
+    height: {{ mermaid_height }};
     width: 100%;
     max-width: 100% !important;
-}}
+}

--- a/sphinxcontrib/mermaid/default.js.j2
+++ b/sphinxcontrib/mermaid/default.js.j2
@@ -1,106 +1,169 @@
-import mermaid from "{mermaid_js_url}";
+import mermaid from "{{ mermaid_js_url }}";
 
-const defaultStyle = document.createElement('style');
-defaultStyle.textContent = `{common_css}`;
-document.head.appendChild(defaultStyle);
+{% if mermaid_include_elk %}
+import elkLayouts from "{{ mermaid_elk_js_url }}"
+{% endif %}
 
-const fullscreenStyle = document.createElement('style');
-fullscreenStyle.textContent = `{fullscreen_css}`;
-document.head.appendChild(fullscreenStyle);
+const initStyles = () => {
+    const defaultStyle = document.createElement('style');
+    defaultStyle.textContent = `{{ common_css }}`;
+    document.head.appendChild(defaultStyle);
+
+    const fullscreenStyle = document.createElement('style');
+    fullscreenStyle.textContent = `{{ fullscreen_css }}`;
+    document.head.appendChild(fullscreenStyle);
+}
 
 // Detect if page has dark background
-const isDarkTheme = () => {{
+const isDarkTheme = () => {
+    // We use a set of heuristics:
+    // 1. Check for common dark mode classes or attributes
+    // 2. Check computed background color brightness
+    if (document.documentElement.classList.contains('dark') ||
+        document.documentElement.getAttribute('data-theme') === 'dark' ||
+        document.body.classList.contains('dark') ||
+        document.body.getAttribute('data-theme') === 'dark') {
+        // console.log("Dark theme detected via class/attribute");
+        return true;
+    }
+    if (document.documentElement.classList.contains('light') ||
+        document.documentElement.getAttribute('data-theme') === 'light' ||
+        document.body.classList.contains('light') ||
+        document.body.getAttribute('data-theme') === 'light') {
+        // console.log("Light theme detected via class/attribute");
+        return false;
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        // console.log("Dark theme detected via prefers-color-scheme");
+        return true;
+    }
     const bgColor = window.getComputedStyle(document.body).backgroundColor;
     const match = bgColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)/);
-    if (match) {{
+    if (match) {
         const r = parseInt(match[1]);
         const g = parseInt(match[2]);
         const b = parseInt(match[3]);
         const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+        // console.log("Background color brightness:", brightness);
         return brightness < 128;
-    }}
+    }
+    // console.log("No dark or light theme detected, defaulting to light theme");
     return false;
-}};
+};
 
-const load = async () => {{
-    await mermaid.run();
+let darkTheme = isDarkTheme();
+let modal = null;
+let modalContent = null;
+let previousScrollOffset = [window.scrollX, window.scrollY];
 
-    const all_mermaids = document.querySelectorAll(".mermaid");
+const runMermaid = async (rerun) => {
+    console.log("Running mermaid diagrams, rerun =", rerun);
+    // clear all existing mermaid charts
+    let all_mermaids = document.querySelectorAll(".mermaid");
+
+    if (rerun) {
+        all_mermaids.forEach((el) => {
+            if(!el.hasAttribute("data-original-code")) {
+                // store original code
+                // console.log(`Storing original code for first run: `, el.innerHTML);
+                el.setAttribute('data-original-code', el.innerHTML);
+            }
+            if(el.getAttribute("data-processed") === "true") {
+                // remove and restore original
+                el.removeAttribute("data-processed");
+                // console.log(`Restoring original code for re-run: `, el.getAttribute('data-original-code'));
+                el.innerHTML = el.getAttribute('data-original-code');
+            } else {
+                // store original code
+                // console.log(`Storing original code for re-run: `, el.innerHTML);
+                el.setAttribute('data-original-code', el.innerHTML);
+            }
+        });
+        await mermaid.run();
+    }
+
+    all_mermaids = document.querySelectorAll(".mermaid");
     const mermaids_processed = document.querySelectorAll(".mermaid[data-processed='true']");
 
-    if ("{add_zoom}" === "True") {{
-        const mermaids_to_add_zoom = {d3_node_count} === -1 ? all_mermaids.length : {d3_node_count};
-        if(mermaids_to_add_zoom > 0) {{
-            var svgs = d3.selectAll("{d3_selector}");
-            if(all_mermaids.length !== mermaids_processed.length) {{
-                setTimeout(load, 200);
+    if ("{{ add_zoom }}" === "True") {
+        const mermaids_to_add_zoom = {{ d3_node_count }} === -1 ? all_mermaids.length : {{ d3_node_count }};
+        if(mermaids_to_add_zoom > 0) {
+            var svgs = d3.selectAll("{{ d3_selector }}");
+            if(all_mermaids.length !== mermaids_processed.length) {
+                setTimeout(() => runMermaid(false), 200);
                 return;
-            }} else if(svgs.size() !== mermaids_to_add_zoom) {{
-                setTimeout(load, 200);
+            } else if(svgs.size() !== mermaids_to_add_zoom) {
+                setTimeout(() => runMermaid(false), 200);
                 return;
-            }} else {{
-                svgs.each(function() {{
+            } else {
+                svgs.each(function() {
                     var svg = d3.select(this);
                     svg.html("<g class='wrapper'>" + svg.html() + "</g>");
                     var inner = svg.select("g");
-                    var zoom = d3.zoom().on("zoom", function(event) {{
+                    var zoom = d3.zoom().on("zoom", function(event) {
                         inner.attr("transform", event.transform);
-                    }});
+                    });
                     svg.call(zoom);
-                }});
-            }}
-        }}
-    }} else if(all_mermaids.length !== mermaids_processed.length) {{
+                });
+            }
+        }
+    } else if(all_mermaids.length !== mermaids_processed.length) {
         // Wait for mermaid to process all diagrams
-        setTimeout(load, 200);
+        setTimeout(() => runMermaid(false), 200);
         return;
-    }}
-
-    const darkTheme = isDarkTheme();
+    }
 
     // Stop here if not adding fullscreen capability
-    if ("{add_fullscreen}" !== "True") return;
+    if ("{{ add_fullscreen }}" !== "True") return;
 
-    const modal = document.createElement('div');
+    if (modal !== null ) {
+        // Destroy existing modal
+        modal.remove();
+        modal = null;
+        modalContent = null;
+    }
+
+    modal = document.createElement('div');
     modal.className = 'mermaid-fullscreen-modal' + (darkTheme ? ' dark-theme' : '');
     modal.setAttribute('role', 'dialog');
     modal.setAttribute('aria-modal', 'true');
     modal.setAttribute('aria-label', 'Fullscreen diagram viewer');
     modal.innerHTML = `
-        <button class="mermaid-fullscreen-close${{darkTheme ? ' dark-theme' : ''}}" aria-label="Close fullscreen">✕</button>
-        <div class="mermaid-container-fullscreen${{darkTheme ? ' dark-theme' : ''}}"></div>
+        <button class="mermaid-fullscreen-close${darkTheme ? ' dark-theme' : ''}" aria-label="Close fullscreen">✕</button>
+        <div class="mermaid-container-fullscreen${darkTheme ? ' dark-theme' : ''}"></div>
     `;
     document.body.appendChild(modal);
 
-    const modalContent = modal.querySelector('.mermaid-container-fullscreen');
+    modalContent = modal.querySelector('.mermaid-container-fullscreen');
     const closeBtn = modal.querySelector('.mermaid-fullscreen-close');
 
-    let previousScrollOffset = [window.scrollX, window.scrollY];
-
-    const closeModal = () => {{
+    const closeModal = () => {
         modal.classList.remove('active');
         modalContent.innerHTML = '';
         document.body.style.overflow = ''
-        window.scrollTo({{left: previousScrollOffset[0], top: previousScrollOffset[1], behavior: 'instant'}});
-    }};
+        window.scrollTo({left: previousScrollOffset[0], top: previousScrollOffset[1], behavior: 'instant'});
+    };
 
     closeBtn.addEventListener('click', closeModal);
-    modal.addEventListener('click', (e) => {{
+    modal.addEventListener('click', (e) => {
         if (e.target === modal) closeModal();
-    }});
-    document.addEventListener('keydown', (e) => {{
-        if (e.key === 'Escape' && modal.classList.contains('active')) {{
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal.classList.contains('active')) {
             closeModal();
-        }}
-    }});
+        }
+    });
 
-    const allButtons = [];
-
-    document.querySelectorAll('.mermaid').forEach((mermaidDiv) => {{
+    document.querySelectorAll('.mermaid').forEach((mermaidDiv) => {
         if (mermaidDiv.parentNode.classList.contains('mermaid-container') ||
-            mermaidDiv.closest('.mermaid-fullscreen-modal')) {{
+            mermaidDiv.closest('.mermaid-fullscreen-modal')) {
+            // Already processed, adjust button class if needed
+            const existingBtn = mermaidDiv.parentNode.querySelector('.mermaid-fullscreen-btn');
+            if (existingBtn) {
+                existingBtn.className = 'mermaid-fullscreen-btn' + (darkTheme ? ' dark-theme' : '');
+            }
             return;
-        }}
+        }
 
         const container = document.createElement('div');
         container.className = 'mermaid-container';
@@ -110,8 +173,8 @@ const load = async () => {{
         const fullscreenBtn = document.createElement('button');
         fullscreenBtn.className = 'mermaid-fullscreen-btn' + (darkTheme ? ' dark-theme' : '');
         fullscreenBtn.setAttribute('aria-label', 'View diagram in fullscreen');
-        fullscreenBtn.textContent = '{button_text}';
-        fullscreenBtn.style.opacity = '{button_opacity}%';
+        fullscreenBtn.textContent = '{{ button_text }}';
+        fullscreenBtn.style.opacity = '{{ button_opacity }}%';
 
         // Calculate dynamic position based on diagram's margin and padding
         const diagramStyle = window.getComputedStyle(mermaidDiv);
@@ -119,17 +182,17 @@ const load = async () => {{
         const marginRight = parseFloat(diagramStyle.marginRight) || 0;
         const paddingTop = parseFloat(diagramStyle.paddingTop) || 0;
         const paddingRight = parseFloat(diagramStyle.paddingRight) || 0;
-        fullscreenBtn.style.top = `${{marginTop + paddingTop + 4}}px`;
-        fullscreenBtn.style.right = `${{marginRight + paddingRight + 4}}px`;
+        fullscreenBtn.style.top = `${marginTop + paddingTop + 4}px`;
+        fullscreenBtn.style.right = `${marginRight + paddingRight + 4}px`;
 
-        fullscreenBtn.addEventListener('click', () => {{
+        fullscreenBtn.addEventListener('click', () => {
             previousScrollOffset = [window.scroll, window.scrollY];
             const clone = mermaidDiv.cloneNode(true);
             modalContent.innerHTML = '';
             modalContent.appendChild(clone);
 
             const svg = clone.querySelector('svg');
-            if (svg) {{
+            if (svg) {
                 svg.removeAttribute('width');
                 svg.removeAttribute('height');
                 svg.style.width = '100%';
@@ -137,61 +200,73 @@ const load = async () => {{
                 svg.style.maxWidth = '100%';
                 svg.style.sdisplay = 'block';
 
-                if ("{add_zoom}" === "True") {{
-                    setTimeout(() => {{
+                if ("{{ add_zoom }}" === "True") {
+                    setTimeout(() => {
                         const g = svg.querySelector('g');
-                        if (g) {{
+                        if (g) {
                             var svgD3 = d3.select(svg);
                             svgD3.html("<g class='wrapper'>" + svgD3.html() + "</g>");
                             var inner = svgD3.select("g");
-                            var zoom = d3.zoom().on("zoom", function(event) {{
+                            var zoom = d3.zoom().on("zoom", function(event) {
                                 inner.attr("transform", event.transform);
-                            }});
+                            });
                             svgD3.call(zoom);
-                        }}
-                    }}, 100);
-                }}
-            }}
+                        }
+                    }, 100);
+                }
+            }
 
             modal.classList.add('active');
             document.body.style.overflow = 'hidden';
-        }});
-
+        });
         container.appendChild(fullscreenBtn);
-        allButtons.push(fullscreenBtn);
-    }});
+    });
+};
+
+const load = async () => {
+    initStyles();
+
+    await runMermaid(true);
+
+    const reRunIfThemeChanges = async () => {
+        const newDarkTheme = isDarkTheme();
+        if (newDarkTheme !== darkTheme) {
+            darkTheme = newDarkTheme;
+            console.log("Theme change detected, re-running mermaid with", darkTheme ? "dark" : "default", "theme");
+            await mermaid.initialize(
+                {...JSON.parse(
+                    `{{ mermaid_init_config }}`
+                ),
+                ...{ darkMode: darkTheme, theme: darkTheme ? 'dark' : 'default' },
+                }
+            );
+            await runMermaid(true);
+        }
+    };
 
     // Update theme classes when theme changes
-    const updateTheme = () => {{
-        const dark = isDarkTheme();
-        allButtons.forEach(btn => {{
-            if (dark) {{
-                btn.classList.add('dark-theme');
-            }} else {{
-                btn.classList.remove('dark-theme');
-            }}
-        }});
-        if (dark) {{
-            modal.classList.add('dark-theme');
-            modalContent.classList.add('dark-theme');
-            closeBtn.classList.add('dark-theme');
-        }} else {{
-            modal.classList.remove('dark-theme');
-            modalContent.classList.remove('dark-theme');
-            closeBtn.classList.remove('dark-theme');
-        }}
-    }};
-
-    // Watch for theme changes
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(document.documentElement, {{
+    const themeObserver = new MutationObserver(reRunIfThemeChanges);
+    themeObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['class', 'style', 'data-theme']
-    }});
-    observer.observe(document.body, {{
+    });
+    themeObserver.observe(document.body, {
         attributes: true,
-        attributeFilter: ['class', 'style']
-    }});
-}};
+        attributeFilter: ['class', 'style', 'data-theme']
+    });
+};
+
+{% if mermaid_include_elk %}
+mermaid.registerLayoutLoaders(elkLayouts);
+{% endif %}
+
+console.log("Initializing mermaid with", darkTheme ? "dark" : "default", "theme");
+mermaid.initialize(
+    {...JSON.parse(
+        `{{ mermaid_init_config }}`
+    ),
+    ...{ darkMode: darkTheme, theme: darkTheme ? 'dark' : 'default' },
+    }
+);
 
 window.addEventListener("load", load);

--- a/sphinxcontrib/mermaid/fullscreen.css.j2
+++ b/sphinxcontrib/mermaid/fullscreen.css.j2
@@ -1,21 +1,21 @@
-.mermaid-container {{
+.mermaid-container {
     display: flex;
     flex-direction: row;
     width: 100%;
-}}
+}
 
-.mermaid-container > pre {{
+.mermaid-container > pre {
     display: block;
-    width: {mermaid_width};
-}}
+    width: {{ mermaid_width }};
+}
 
-.mermaid-container > pre > svg {{
-    height: {mermaid_height};
+.mermaid-container > pre > svg {
+    height: {{ mermaid_height }};
     width: 100%;
     max-width: 100% !important;
-}}
+}
 
-.mermaid-fullscreen-btn {{
+.mermaid-fullscreen-btn {
     width: 28px;
     height: 28px;
     background: rgba(255, 255, 255, 0.95);
@@ -31,27 +31,27 @@
     line-height: 1;
     padding: 0;
     color: #333;
-}}
+}
 
-.mermaid-fullscreen-btn:hover {{
+.mermaid-fullscreen-btn:hover {
     opacity: 100% !important;
     background: rgba(255, 255, 255, 1);
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
     transform: scale(1.1);
-}}
+}
 
-.mermaid-fullscreen-btn.dark-theme {{
+.mermaid-fullscreen-btn.dark-theme {
     background: rgba(50, 50, 50, 0.95);
     border: 1px solid rgba(255, 255, 255, 0.3);
     color: #e0e0e0;
-}}
+}
 
-.mermaid-fullscreen-btn.dark-theme:hover {{
+.mermaid-fullscreen-btn.dark-theme:hover {
     background: rgba(60, 60, 60, 1);
     box-shadow: 0 3px 10px rgba(255, 255, 255, 0.2);
-}}
+}
 
-.mermaid-fullscreen-modal {{
+.mermaid-fullscreen-modal {
     display: none;
     position: fixed !important;
     top: 0 !important;
@@ -62,19 +62,19 @@
     z-index: 9999;
     padding: 20px;
     overflow: auto;
-}}
+}
 
-.mermaid-fullscreen-modal.dark-theme {{
+.mermaid-fullscreen-modal.dark-theme {
     background: rgba(0, 0, 0, 0.98);
-}}
+}
 
-.mermaid-fullscreen-modal.active {{
+.mermaid-fullscreen-modal.active {
     display: flex;
     align-items: center;
     justify-content: center;
-}}
+}
 
-.mermaid-container-fullscreen {{
+.mermaid-container-fullscreen {
     position: relative;
     width: 95vw;
     height: 90vh;
@@ -88,28 +88,28 @@
     display: flex;
     align-items: center;
     justify-content: center;
-}}
+}
 
-.mermaid-container-fullscreen.dark-theme {{
+.mermaid-container-fullscreen.dark-theme {
     background: #1a1a1a;
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.8);
-}}
+}
 
-.mermaid-container-fullscreen pre.mermaid {{
+.mermaid-container-fullscreen pre.mermaid {
     width: 100%;
     height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-}}
+}
 
-.mermaid-container-fullscreen .mermaid svg {{
+.mermaid-container-fullscreen .mermaid svg {
     height: 100% !important;
     width: 100% !important;
     cursor: grab;
-}}
+}
 
-.mermaid-fullscreen-close {{
+.mermaid-fullscreen-close {
     position: fixed !important;
     top: 20px !important;
     right: 20px !important;
@@ -128,25 +128,25 @@
     font-size: 24px;
     line-height: 1;
     color: #333;
-}}
+}
 
-.mermaid-fullscreen-close:hover {{
+.mermaid-fullscreen-close:hover {
     background: white;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
     transform: scale(1.1);
-}}
+}
 
-.mermaid-fullscreen-close.dark-theme {{
+.mermaid-fullscreen-close.dark-theme {
     background: rgba(50, 50, 50, 0.95);
     border: 1px solid rgba(255, 255, 255, 0.2);
     color: #e0e0e0;
-}}
+}
 
-.mermaid-fullscreen-close.dark-theme:hover {{
+.mermaid-fullscreen-close.dark-theme:hover {
     background: rgba(60, 60, 60, 1);
     box-shadow: 0 6px 16px rgba(255, 255, 255, 0.2);
-}}
+}
 
-.mermaid-fullscreen-modal .mermaid-fullscreen-btn {{
+.mermaid-fullscreen-modal .mermaid-fullscreen-btn {
     display: none !important;
-}}
+}

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -17,9 +17,20 @@ def index(app, build_all):
 @pytest.mark.sphinx("html", testroot="basic")
 def test_html_raw(index):
     assert "mermaid.run()" in index
-    assert '<script type="module" src="https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"></script>' in index
     assert (
-        '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs";import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.0/dist/mermaid-layout-elk.esm.min.mjs";mermaid.registerLayoutLoaders(elkLayouts);mermaid.initialize({startOnLoad:false});</script>'
+        'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"'
+        in index
+    )
+    assert (
+        'import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.0/dist/mermaid-layout-elk.esm.min.mjs"'
+        in index
+    )
+    assert (
+        'mermaid.registerLayoutLoaders(elkLayouts);'
+        in index
+    )
+    assert (
+        '{"startOnLoad": false}'
         in index
     )
     assert (
@@ -59,7 +70,10 @@ def test_html_no_zoom(index):
 def test_conf_mermaid_version(app, index):
     assert "mermaid.run()" in index
     assert app.config.mermaid_version == "10.3.0"
-    assert '<script type="module" src="https://cdn.jsdelivr.net/npm/mermaid@10.3.0/dist/mermaid.esm.min.mjs"></script>' in index
+    assert (
+        'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10.3.0/dist/mermaid.esm.min.mjs"'
+        in index
+    )
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_elk": ""})
@@ -87,28 +101,45 @@ def test_conf_d3_local(app, index):
     assert "cdn.jsdelivr.net/npm/d3" not in index
 
 
-@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_init_js": "custom script;"})
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_init_config": {"startOnLoad": True}})
 def test_mermaid_init_js(index):
     assert "mermaid.run()" in index
     assert (
-        '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"; mermaid.initialize({startOnLoad:false});</script>'
+        '{"startOnLoad": false}'
         not in index
     )
-    assert '<script type="module">custom script;</script>' in index
-
+    assert (
+        '{"startOnLoad": true}'
+        in index
+    )
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_include_elk": "latest"})
 def test_mermaid_with_elk(app, index):
     assert "mermaid.run()" in index
-    assert '<script type="module" src="https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"></script>' in index
+    assert (
+        'import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk/dist/mermaid-layout-elk.esm.min.mjs"'
+        in index
+    )
 
 
 @pytest.mark.sphinx("html", testroot="markdown")
 def test_html_raw_from_markdown(index):
     assert "mermaid.run()" in index
-    assert '<script type="module" src="https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"></script>' in index
+    assert "mermaid.run()" in index
     assert (
-        '<script type="module">import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs";import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.0/dist/mermaid-layout-elk.esm.min.mjs";mermaid.registerLayoutLoaders(elkLayouts);mermaid.initialize({startOnLoad:false});</script>'
+        'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.12.1/dist/mermaid.esm.min.mjs"'
+        in index
+    )
+    assert (
+        'import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.0/dist/mermaid-layout-elk.esm.min.mjs"'
+        in index
+    )
+    assert (
+        'mermaid.registerLayoutLoaders(elkLayouts);'
+        in index
+    )
+    assert (
+        '{"startOnLoad": false}'
         in index
     )
     assert (
@@ -121,7 +152,7 @@ def test_html_raw_from_markdown(index):
 def test_fullscreen_enabled(index):
     """Test that fullscreen JavaScript is added when enabled."""
     assert "mermaid.run()" in index
-    assert ".mermaid-fullscreen-btn" in index
+    assert ".mermaid-fullscreen-btn:hover" in index
     assert ".mermaid-fullscreen-modal" in index
     assert "mermaid-fullscreen-close" in index
 
@@ -130,7 +161,7 @@ def test_fullscreen_enabled(index):
 def test_fullscreen_disabled(index):
     """Test that fullscreen is not added when disabled."""
     assert "mermaid.run()" in index
-    assert ".mermaid-fullscreen-btn" not in index
+    assert ".mermaid-fullscreen-btn:hover" not in index
 
 
 @pytest.mark.sphinx("html", testroot="fullscreen", confoverrides={"mermaid_d3_zoom": True})


### PR DESCRIPTION
Fixes #78
Should fix #170 
Closes #172 
Closes #165 

Top chart has hardcoded dark theme, bottom chart does not:

![demo](https://github.com/user-attachments/assets/3dc2fdd5-36cf-4243-be29-6f75bd5ed758)


Toggling the theme triggers:

- reinitialize mermaid
- reinitialize all charts
- rerun mermaid
- toggle fullscreen buttons

We look in the following places for dark theme:
```javascript
    // We use a set of heuristics:
    // 1. Check for common dark mode classes or attributes
    // 2. Check computed background color brightness
    if (document.documentElement.classList.contains('dark') ||
        document.documentElement.getAttribute('data-theme') === 'dark' ||
        document.body.classList.contains('dark') ||
        document.body.getAttribute('data-theme') === 'dark') {
        // console.log("Dark theme detected via class/attribute");
        return true;
    }
    if (document.documentElement.classList.contains('light') ||
        document.documentElement.getAttribute('data-theme') === 'light' ||
        document.body.classList.contains('light') ||
        document.body.getAttribute('data-theme') === 'light') {
        // console.log("Light theme detected via class/attribute");
        return false;
    }
    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
        // console.log("Dark theme detected via prefers-color-scheme");
        return true;
    }
    const bgColor = window.getComputedStyle(document.body).backgroundColor;
    const match = bgColor.match(/rgb\((\d+),\s*(\d+),\s*(\d+)/);
    if (match) {
        const r = parseInt(match[1]);
        const g = parseInt(match[2]);
        const b = parseInt(match[3]);
        const brightness = (r * 299 + g * 587 + b * 114) / 1000;
        // console.log("Background color brightness:", brightness);
        return brightness < 128;
    }
    // console.log("No dark or light theme detected, defaulting to light theme");
    return false;
};
```
