### PR TITLE
adding 'mermaid_config' config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ use this extra function.
 Optional override of arguments to `mermaid.initialize()`, passed in as
 a JSON. Defaults to `{ "startOnLoad": True}`.
 
+### `mermaid_config`
+
+Optional default for each Mermaid directive's `config` frontmatter. Set it to
+a dictionary in `conf.py`:
+
+```python
+mermaid_config = {
+    "theme": "base",
+    "themeVariables": {"primaryColor": "#BB2528"},
+}
+```
+
+A directive's `:config:` option replaces this default for that diagram.
+
 ### `mermaid_dark_theme`
 
 The mermaid theme to use when dark mode is detected. Defaults to `"dark"`.

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -160,9 +160,9 @@ class Mermaid(Directive):
         if "config" in self.options:
             mm_config += "\n"
             mm_config += dump({"config": loads(self.options["config"])})
-        elif 'mermaid_config' in self.state_machine.document.settings.env.config:
+        elif self.state_machine.document.settings.env.config.mermaid_config is not None:
             mm_config += "\n"
-            mm_config += dump({"config": self.state_machine.document.settings.env.config['mermaid_config']})
+            mm_config += dump({"config": self.state_machine.document.settings.env.config.mermaid_config})
         if "title" in self.options:
             mm_config += "\n"
             mm_config += f"title: {self.options['title']}"
@@ -615,7 +615,7 @@ def setup(app):
     app.add_config_value("mermaid_params", list(), "html")
     app.add_config_value("mermaid_verbose", False, "html")
     app.add_config_value("mermaid_sequence_config", False, "html")
-    app.add_config_value("mermaid_config", None, "html")
+    app.add_config_value("mermaid_config", None, "env")
 
     app.add_config_value("mermaid_init_config", {"startOnLoad": False}, "html")
     app.add_config_value("mermaid_dark_theme", "dark", "html")

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -160,6 +160,9 @@ class Mermaid(Directive):
         if "config" in self.options:
             mm_config += "\n"
             mm_config += dump({"config": loads(self.options["config"])})
+        elif 'mermaid_config' in self.state_machine.document.settings.env.config:
+            mm_config += "\n"
+            mm_config += dump({"config": self.state_machine.document.settings.env.config['mermaid_config']})
         if "title" in self.options:
             mm_config += "\n"
             mm_config += f"title: {self.options['title']}"
@@ -612,6 +615,7 @@ def setup(app):
     app.add_config_value("mermaid_params", list(), "html")
     app.add_config_value("mermaid_verbose", False, "html")
     app.add_config_value("mermaid_sequence_config", False, "html")
+    app.add_config_value("mermaid_config", None, "html")
 
     app.add_config_value("mermaid_init_config", {"startOnLoad": False}, "html")
     app.add_config_value("mermaid_dark_theme", "dark", "html")

--- a/tests/roots/test-config/conf.py
+++ b/tests/roots/test-config/conf.py
@@ -1,0 +1,7 @@
+extensions = ["sphinxcontrib.mermaid"]
+exclude_patterns = ["_build"]
+
+mermaid_config = {
+    "theme": "base",
+    "themeVariables": {"primaryColor": "#BB2528"},
+}

--- a/tests/roots/test-config/index.rst
+++ b/tests/roots/test-config/index.rst
@@ -1,0 +1,13 @@
+Global Mermaid configuration
+============================
+
+.. mermaid::
+
+   graph TD
+      a --> b
+
+.. mermaid::
+   :config: {"theme": "forest"}
+
+   graph TD
+      c --> d

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -130,6 +130,14 @@ def test_mermaid_init_js(index):
         in index
     )
 
+
+@pytest.mark.sphinx("html", testroot="config")
+def test_mermaid_config(index):
+    assert "config:\n  theme: base\n  themeVariables:\n    primaryColor: '#BB2528'" in index
+    assert "config:\n  theme: forest" in index
+    assert index.count("primaryColor: '#BB2528'") == 1
+
+
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_include_elk": True, "mermaid_elk_version": "latest"})
 def test_mermaid_with_elk(app, index):
     assert "mermaid.run(" in index


### PR DESCRIPTION
This change allows for global configuration settings across sphinx, and is very helpful for setting a theme (custom or otherwise) that can be applied to the entire project. I could not find a reasonable alternative solution to this, and was resorting to copy/pasting :config: option for each directive.

Now you can specify in your `conf.py` script your configuration as follows:

```python
# set up extensions
extensions = ['sphinxcontrib.mermaid',]

# globally-applicable configuration
mermaid_config = {
    "theme":"base",
    "themeVariables": {"primaryColor" : "#BB2528"}
}
```

You can override these directives 

```rst
.. mermaid:
    :caption: Use custom theme defined in ``conf.py``
    graph TD
        a --> b

.. mermaid:
    :caption: Override for this diagram
    :config: {"theme":"forest"}
    graph TD
        a --> b
```
