### PR TITLE
Add module‑based links and display all classes in autoclasstree

### DIFF
--- a/sphinxcontrib/mermaid/autoclassdiag.py
+++ b/sphinxcontrib/mermaid/autoclassdiag.py
@@ -35,11 +35,9 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
 
     def get_tree(cls):
         for base in cls.__bases__:
-            if base.__name__ == "object":
-                continue
             if namespace and not base.__module__.startswith(namespace):
                 continue
-            inheritances.add((base.__name__, cls.__name__))
+            inheritances.add((base.__name__, cls.__name__, cls.__module__))
             if full:
                 get_tree(base)
 
@@ -48,8 +46,19 @@ def class_diagram(*cls_or_modules, full=False, strict=False, namespace=None):
 
     if not inheritances:
         return ""
+    sorted_inheritances = sorted(inheritances)
 
-    return "classDiagram\n" + "\n".join(f"  {a} <|-- {b}" for a, b in sorted(inheritances))
+    classes = "\n  ".join(
+        f"class {class_name}\n  "
+        f'link {class_name} "#{module}.{class_name}"'
+        for _, class_name, module in sorted_inheritances
+    )
+    links = "\n  ".join(
+        f"{base_name} <|-- {class_name}"
+        for base_name, class_name, _ in sorted_inheritances
+        if base_name != 'object'
+    )
+    return f"classDiagram\n  {classes}\n  {links}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Add module‑based links and display all classes in `autoclasstree`.

## What’s changed
1. **Add module‑based class links**  
   - Each class now includes a `link` directive pointing to its full module path (e.g., `link MyClass "mymodule.MyClass"`).
   - Helps navigation in generated documentation.

2. **Display all classes, even without inheritance**  
   - Before: classes with no custom base classes were omitted.
   - Now: all classes are listed in the diagram, regardless of inheritance.
   - Fixes edge cases where classes were missing from diagrams (see PR #118).