### PR TITLE
Add CSP compliance: external init script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,32 @@ Customizes the fullscreen button opacity, to avoid fully obscuring
 important chart content. Default is `50` (percent). You can use any
 value from 0 to 100. Button becomes fully opaque on hover.
 
+### `mermaid_external_init`
+
+**CSP Compliance**: When set to `True`, writes the mermaid initialization 
+script to an external JavaScript file instead of injecting it inline. This 
+enables Content Security Policy (CSP) compliance on sites that enforce 
+`script-src 'self'` without `'unsafe-inline'`. Default is `False` (inline script).
+
+Example:
+```python
+mermaid_external_init = True
+```
+
+### `mermaid_init_filename_prefix`
+
+Optional prefix for the external mermaid initialization filename. Defaults to 
+the project name from `project` config value. The filename will be 
+`mermaid-init-{prefix}-{hash}.js` where the hash is based on the script content.
+
+This is useful when hosting multiple documentation sets on the same domain to 
+prevent filename collisions.
+
+Example:
+```python
+mermaid_init_filename_prefix = "my-docs"
+```
+
 ## Markdown support
 
 You can include Mermaid diagrams in your Markdown documents in Sphinx.


### PR DESCRIPTION
# Add CSP compliance: external init script option

Fixes #222

## Problem

sphinxcontrib-mermaid currently injects inline `<script type="module">` tags containing the mermaid initialization code. This violates Content Security Policy (CSP) on production sites that enforce `script-src 'self'` without `'unsafe-inline'`, causing mermaid diagrams to silently fail.

**Current behavior:**
```html
<script type="module">
import mermaid from "/js/mermaid.esm.min.mjs";
mermaid.initialize({...});
</script>
```

**CSP violation:**
```
Refused to execute inline script because it violates the following 
Content Security Policy directive: "script-src 'self'"
```

This affects enterprise documentation portals, government sites, and any deployment with strict security policies.

## Solution

Add two new config options that enable writing the initialization script to an external file:

```python
# conf.py
mermaid_external_init = True  # Default: False (backward compatible)
mermaid_init_filename_prefix = "my-docs"  # Optional, defaults to project name
```

**Generated output:**
```html
<script type="module" src="_static/mermaid-init-my-docs-a1b2c3d4.js"></script>
```

## Implementation

Uses existing Sphinx functionality - no Sphinx changes needed:
- **Inline mode** (current): `app.add_js_file(None, body=script_content)`
- **External mode** (new): `app.add_js_file(filename)` after writing file to disk

**Key features:**
- Writes to `_static/mermaid-init-{prefix}-{hash}.js` in output directory
- Sanitizes prefix (lowercase, hyphens) for web safety
- Content-addressed filename (hash) for cache invalidation
- Prevents filename collisions when hosting multiple doc sets
- Fully backward compatible - default behavior unchanged

## Changes

- Added `mermaid_external_init` config value (default: `False`)
- Added `mermaid_init_filename_prefix` config value (default: `None`, uses project name)
- Added `add_js_file_or_inline()` helper function
- Updated all `add_js_file()` calls to use helper
- Added documentation to README.md
- Added 4 test cases covering all scenarios

## Testing

**New tests:**
- `test_external_init_enabled` - Verifies external file creation
- `test_external_init_disabled` - Verifies default inline behavior
- `test_external_init_custom_prefix` - Tests custom prefix
- `test_external_init_sanitized_project_name` - Tests filename sanitization

**Production testing:**
- Tested on enterprise documentation platform with strict CSP
- Verified diagrams render correctly with external scripts
- Confirmed no inline scripts in generated HTML

## Benefits

- **CSP compliant**: External scripts from same origin satisfy `script-src 'self'`
- **No silent failures**: Diagrams work regardless of CSP policy changes
- **Cache-friendly**: Content-addressed filenames enable proper caching
- **Collision-safe**: Prefix prevents conflicts in multi-tenant hosting
- **Backward compatible**: Existing configurations work unchanged
