### PR TITLE
Fix fullscreen button positioning inconsistency

### DIFF
--- a/sphinxcontrib/mermaid/fullscreen.css.j2
+++ b/sphinxcontrib/mermaid/fullscreen.css.j2
@@ -1,4 +1,5 @@
 .mermaid-container {
+    position: relative;
     display: flex;
     flex-direction: row;
     width: 100%;
@@ -16,6 +17,7 @@
 }
 
 .mermaid-fullscreen-btn {
+    position: absolute;
     width: 28px;
     height: 28px;
     background: rgba(255, 255, 255, 0.95);

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -186,6 +186,8 @@ def test_html_raw_from_markdown(index):
 def test_fullscreen_enabled(index):
     """Test that fullscreen JavaScript is added when enabled."""
     assert "mermaid.run(" in index
+    assert ".mermaid-container {\n    position: relative;" in index
+    assert ".mermaid-fullscreen-btn {\n    position: absolute;" in index
     assert ".mermaid-fullscreen-btn:hover" in index
     assert ".mermaid-fullscreen-modal" in index
     assert "mermaid-fullscreen-close" in index


### PR DESCRIPTION
The fullscreen button (⛶) was inconsistently visible, appearing only in certain mouse positions due to missing CSS positioning properties.

Root cause:
- The JavaScript (default.js.j2) sets 'top' and 'right' styles on the fullscreen button, but the CSS never set 'position: absolute'
- The container lacked 'position: relative', making positioning unpredictable and browser-dependent

Solution:
- Add 'position: relative' to .mermaid-container
- Add 'position: absolute' to .mermaid-fullscreen-btn

This ensures the button is consistently positioned in the top-right corner of the diagram container using the top/right values set by JavaScript.

Tested with Playwright automation - button now appears consistently and clicks successfully to open the fullscreen modal.

- Contributes to fix up #224, at least was identified by Claude code as one of the factors.