### PR TITLE
Add mermaid_dark_theme and mermaid_light_theme config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `mermaid_dark_theme` and `mermaid_light_theme` config options for configurable theme switching
+
 ## 2.0.1 (March 5, 2026)
 
 - Export `runMermaid` to window for hot reloading frontend

--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ use this extra function.
 Optional override of arguments to `mermaid.initialize()`, passed in as
 a JSON. Defaults to `{ "startOnLoad": True}`.
 
+### `mermaid_dark_theme`
+
+The mermaid theme to use when dark mode is detected. Defaults to `"dark"`.
+Valid values are any [mermaid theme](https://mermaid.js.org/config/theming.html): `"default"`, `"neutral"`, `"dark"`, `"forest"`, `"base"`.
+
+### `mermaid_light_theme`
+
+The mermaid theme to use when light mode is detected. Defaults to `"default"`.
+Valid values are the same as for `mermaid_dark_theme`.
+
+For a theme that works well in both dark and light mode, set both to `"neutral"`:
+
+```python
+mermaid_dark_theme = "neutral"
+mermaid_light_theme = "neutral"
+```
+
 ### `mermaid_version`
 
 The version of mermaid that will be used to parse `raw` output in HTML

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -455,6 +455,8 @@ def install_js(
     common_render_args = dict(
         mermaid_js_url=_mermaid_js_url,
         mermaid_init_config=dumps(app.config.mermaid_init_config),
+        mermaid_dark_theme=app.config.mermaid_dark_theme,
+        mermaid_light_theme=app.config.mermaid_light_theme,
         mermaid_include_elk=_mermaid_elk_js_url is not None,
         mermaid_include_zenuml=_mermaid_zenuml_js_url is not None,
         mermaid_elk_js_url=_mermaid_elk_js_url,
@@ -593,6 +595,8 @@ def setup(app):
     app.add_config_value("mermaid_sequence_config", False, "html")
 
     app.add_config_value("mermaid_init_config", {"startOnLoad": False}, "html")
+    app.add_config_value("mermaid_dark_theme", "dark", "html")
+    app.add_config_value("mermaid_light_theme", "default", "html")
     app.add_config_value("mermaid_version", "11.12.1", "html")
     app.add_config_value("mermaid_use_local", "", "html")
 

--- a/sphinxcontrib/mermaid/default.js.j2
+++ b/sphinxcontrib/mermaid/default.js.j2
@@ -236,12 +236,12 @@ const load = async () => {
         const newDarkTheme = isDarkTheme();
         if (newDarkTheme !== darkTheme) {
             darkTheme = newDarkTheme;
-            console.log("Theme change detected, re-running mermaid with", darkTheme ? "dark" : "default", "theme");
+            console.log("Theme change detected, re-running mermaid with", darkTheme ? "{{ mermaid_dark_theme }}" : "{{ mermaid_light_theme }}", "theme");
             await mermaid.initialize(
                 {...JSON.parse(
                     `{{ mermaid_init_config }}`
                 ),
-                ...{ darkMode: darkTheme, theme: darkTheme ? 'dark' : 'default' },
+                ...{ darkMode: darkTheme, theme: darkTheme ? '{{ mermaid_dark_theme }}' : '{{ mermaid_light_theme }}' },
                 }
             );
             await runMermaid(true);
@@ -268,12 +268,12 @@ mermaid.registerLayoutLoaders(elkLayouts);
 mermaid.registerExternalDiagrams([zenumlLayouts]);
 {% endif %}
 
-console.log("Initializing mermaid with", darkTheme ? "dark" : "default", "theme");
+console.log("Initializing mermaid with", darkTheme ? "{{ mermaid_dark_theme }}" : "{{ mermaid_light_theme }}", "theme");
 mermaid.initialize(
     {...JSON.parse(
         `{{ mermaid_init_config }}`
     ),
-    ...{ darkMode: darkTheme, theme: darkTheme ? 'dark' : 'default' },
+    ...{ darkMode: darkTheme, theme: darkTheme ? '{{ mermaid_dark_theme }}' : '{{ mermaid_light_theme }}' },
     }
 );
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -172,3 +172,21 @@ def test_custom_fullscreen_button(index):
     """Test custom fullscreen button icon."""
     assert "mermaid.run()" in index
     assert "[+]" in index
+
+
+@pytest.mark.sphinx("html", testroot="basic")
+def test_mermaid_theme_defaults(index):
+    """Default theme values are 'dark' and 'default'."""
+    assert "theme: darkTheme ? 'dark' : 'default'" in index
+
+
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_dark_theme": "neutral", "mermaid_light_theme": "neutral"})
+def test_mermaid_theme_both_custom(index):
+    """Both theme values can be overridden."""
+    assert "theme: darkTheme ? 'neutral' : 'neutral'" in index
+
+
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_dark_theme": "neutral"})
+def test_mermaid_theme_dark_only(index):
+    """Only dark theme overridden, light stays default."""
+    assert "theme: darkTheme ? 'neutral' : 'default'" in index


### PR DESCRIPTION
The dark/light theme values in `default.js.j2` are hardcoded to `'dark'` and `'default'`. This always overrides any `theme` value set via `mermaid_init_config`, making it impossible to use e.g. `'neutral'` (which works well in both dark and light mode).

This adds two new config options:

- `mermaid_dark_theme` (default: `"dark"`) — mermaid theme used when dark mode is detected
- `mermaid_light_theme` (default: `"default"`) — mermaid theme used when light mode is detected

Example usage for a theme that works in both modes:

```python
mermaid_dark_theme = "neutral"
mermaid_light_theme = "neutral"
```

Backwards compatible — defaults preserve the current behavior.