### PR TITLE
Resolve local Mermaid/ELK/ZenUML/D3 JS paths under html_static_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,13 @@ The default is `"11.12.1"`.
 
 ### `mermaid_use_local`
 
-Optional path to a local installation of `mermaid.esm.min.mjs`. By
-default, we will pull from jsdelivr.
+Optional location of a local copy of `mermaid.esm.min.mjs`. By default,
+we will pull from jsdelivr.
+
+The value can be either an absolute URL or a path relative to
+`html_static_path` (e.g. `vendor/mermaid.esm.min.mjs` if the file is
+vendored at `_static/vendor/mermaid.esm.min.mjs`). The same applies to
+the other `*_use_local` options below.
 
 ### `mermaid_include_elk`
 
@@ -266,19 +271,18 @@ is `"0.2.2"`.
 
 ### `mermaid_elk_use_local`
 
-Optional path to a local installation of
-`mermaid-layout-elk.esm.min.mjs`. By default, we will pull from
-jsdelivr.
+Optional location of a local copy of `mermaid-layout-elk.esm.min.mjs`.
+See [`mermaid_use_local`](#mermaid_use_local) for accepted values.
 
 ### `mermaid_zenuml_use_local`
 
-Optional path to a local installation of `mermaid-zenuml.esm.min.mjs`.
-By default, we will pull from jsdelivr.
+Optional location of a local copy of `mermaid-zenuml.esm.min.mjs`.
+See [`mermaid_use_local`](#mermaid_use_local) for accepted values.
 
 ### `d3_use_local`
 
-Optional path to a local installation of `d3.min.js`. By default, we
-will pull from jsdelivr.
+Optional location of a local copy of `d3.min.js`.
+See [`mermaid_use_local`](#mermaid_use_local) for accepted values.
 
 ### `d3_version`
 

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -397,6 +397,18 @@ def man_visit_mermaid(self, node):
     raise nodes.SkipNode
 
 
+def _resolve_local_url(url: str, context: dict) -> str:
+    """Resolve a *_use_local config value to a URL.
+
+    If the value is an absolute URL (``http://``, ``https://``, ``//``, ``/``),
+    it is returned unchanged. Otherwise it is treated as a path relative to
+    ``html_static_path`` and resolved to a URL relative to the current page.
+    """
+    if not url or url.startswith(("http://", "https://", "//", "/")):
+        return url
+    return context["pathto"]("_static/" + url, resource=True)
+
+
 def install_js(
     app: Sphinx,
     pagename,
@@ -410,7 +422,7 @@ def install_js(
 
     # Add required JavaScript
     if app.config.mermaid_use_local:
-        _mermaid_js_url = app.config.mermaid_use_local
+        _mermaid_js_url = _resolve_local_url(app.config.mermaid_use_local, context)
     elif app.config.mermaid_version == "latest":
         _mermaid_js_url = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs"
     elif Version(app.config.mermaid_version) > Version("10.2.0"):
@@ -421,7 +433,7 @@ def install_js(
     _mermaid_elk_js_url = None
     if app.config.mermaid_include_elk:
         if app.config.mermaid_elk_use_local:
-            _mermaid_elk_js_url = app.config.mermaid_elk_use_local
+            _mermaid_elk_js_url = _resolve_local_url(app.config.mermaid_elk_use_local, context)
         elif app.config.mermaid_elk_version == "latest":
             _mermaid_elk_js_url = "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk/dist/mermaid-layout-elk.esm.min.mjs"
         elif app.config.mermaid_elk_version:
@@ -432,7 +444,7 @@ def install_js(
     _mermaid_zenuml_js_url = None
     if app.config.mermaid_include_zenuml:
         if app.config.mermaid_zenuml_use_local:
-            _mermaid_zenuml_js_url = app.config.mermaid_zenuml_use_local
+            _mermaid_zenuml_js_url = _resolve_local_url(app.config.mermaid_zenuml_use_local, context)
         elif app.config.mermaid_zenuml_version == "latest":
             _mermaid_zenuml_js_url = "https://cdn.jsdelivr.net/npm/@mermaid-js/mermaid-zenuml/dist/mermaid-zenuml.esm.min.mjs"
         elif app.config.mermaid_zenuml_version:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -75,13 +75,23 @@ def test_conf_mermaid_version(app, index):
 def test_conf_mermaid_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
+    assert 'import mermaid from "_static/test"' in index
 
 
-@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_elk_use_local": "test"})
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_elk": True, "mermaid_elk_use_local": "test"})
 def test_conf_mermaid_elk_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
     assert "mermaid-layout-elk.esm.min.mjs" not in index
+    assert 'import elkLayouts from "_static/test"' in index
+
+
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_zenuml": True, "mermaid_zenuml_use_local": "test"})
+def test_conf_mermaid_zenuml_local(app, index):
+    assert "mermaid.run()" in index
+    assert "mermaid.min.js" not in index
+    assert "mermaid-zenuml.esm.min.mjs" not in index
+    assert 'import zenumlLayouts from "_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"d3_version": "1.2.3", "mermaid_include_elk": False})
@@ -94,6 +104,10 @@ def test_conf_d3_version(app, index):
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"d3_use_local": "test"})
 def test_conf_d3_local(app, index):
     assert "cdn.jsdelivr.net/npm/d3" not in index
+    assert re.search(
+        r'<script src="[^"]*_static/test(?:\?[^"]*)?"></script>',
+        index,
+    )
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_init_config": {"startOnLoad": True}})
@@ -113,6 +127,15 @@ def test_mermaid_with_elk(app, index):
     assert "mermaid.run()" in index
     assert (
         'import elkLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk/dist/mermaid-layout-elk.esm.min.mjs"'
+        in index
+    )
+
+
+@pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_include_zenuml": True, "mermaid_zenuml_version": "latest"})
+def test_mermaid_with_zenuml(app, index):
+    assert "mermaid.run()" in index
+    assert (
+        'import zenumlLayouts from "https://cdn.jsdelivr.net/npm/@mermaid-js/mermaid-zenuml/dist/mermaid-zenuml.esm.min.mjs"'
         in index
     )
 


### PR DESCRIPTION
The way the ..._use_local paths were treated made it impossible to provide anything but am absolute URL, which is not always practical.
This change makes sure that whenever a non absolute URL is provided, it is treated as being relative to html_static_path and turned into a page-correct URL.