### PR TITLE
chore: remove asyncio_mode from pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ test = [
 [project.scripts]
 
 [tool.pytest.ini_options]
-asyncio_mode = "strict"
 testpaths = "tests"
 
 [tool.ruff]


### PR DESCRIPTION
pytest-asyncio is not a test dependency and asyncio_mode has no effect
here, causing a PytestConfigWarning on every test run.
