### PR TITLE
fix: Capture mmdc error message as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## 2.0.2 (April 30, 2026)
+
 - Add `mermaid_dark_theme` and `mermaid_light_theme` config options for configurable theme switching
+- Resolve local Mermaid/ELK/ZenUML/D3 JS paths under `html_static_path`
 
 ## 2.0.1 (March 5, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Capture mmdc error message as string for nicer error display
+
 ## 2.0.2 (April 30, 2026)
 
 - Add `mermaid_dark_theme` and `mermaid_light_theme` config options for configurable theme switching

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -234,12 +234,12 @@ def render_mm(self, code, options, _fmt, prefix="mermaid"):
             mm_args.extend(["--configFile", self.builder.config.mermaid_sequence_config])
 
         try:
-            p = Popen(mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE)
+            p = Popen(mm_args, shell=mermaid_cmd_shell, stdout=PIPE, stdin=PIPE, stderr=PIPE, text=True)
         except FileNotFoundError:
             logger.warning("command %r cannot be run (needed for mermaid output), check the mermaid_cmd setting" % mermaid_cmd)
             return None, None
 
-        stdout, stderr = p.communicate(str.encode(code))
+        stdout, stderr = p.communicate(code)
         if self.builder.config.mermaid_verbose:
             logger.info(stdout)
 

--- a/tests/roots/test-invalid/conf.py
+++ b/tests/roots/test-invalid/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinxcontrib.mermaid"]
+exclude_patterns = ["_build"]
+mermaid_output_format = "svg"

--- a/tests/roots/test-invalid/index.rst
+++ b/tests/roots/test-invalid/index.rst
@@ -1,0 +1,6 @@
+Invalid mermaid diagram
+-----------------------
+
+.. mermaid::
+
+   this is not valid mermaid syntax %%%

--- a/tests/roots/test-invalid/mmdc_fake
+++ b/tests/roots/test-invalid/mmdc_fake
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import sys
+
+print("Generating single mermaid chart")
+print("Error: bad syntax", file=sys.stderr)
+print("something else", file=sys.stderr)
+sys.exit(1)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,4 +1,6 @@
 import re
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -213,3 +215,23 @@ def test_mermaid_theme_both_custom(index):
 def test_mermaid_theme_dark_only(index):
     """Only dark theme overridden, light stays default."""
     assert "theme: darkTheme ? 'neutral' : 'default'" in index
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="invalid",
+    confoverrides={
+        # Call a fake mmdc script that always fails, to test error handling.
+        # mmdc_fake is written in Python to make the test work on Windows.
+        "mermaid_cmd": [
+            sys.executable,
+            str(Path(__file__).parent / "roots/test-invalid/mmdc_fake"),
+        ],
+        "mermaid_output_format": "svg",
+    },
+)
+def test_render_error_message(app):
+    """The stderr string from a failed mmdc run appears verbatim in the Sphinx warning."""
+    app.builder.build_all()
+    warnings = app._warning.getvalue()
+    assert "Mermaid exited with error:\n[stderr]\nError: bad syntax\nsomething else" in warnings


### PR DESCRIPTION
When rendering to SVG with faulty Mermaid code, I get an error message
with a binary string (with `b'...\n`), which is hard to read for end
users. Capture the error message as string before it ends up in the
`MermaidError` exception. Now the exception contains a string and looks
much nicer.

```
Mermaid exited with error:
[stderr]

Error: Packet block 294 - 296 is not contiguous. It should start from 441.
    at populate (file://...mermaid-11.15.0.js:156484:19)
    at Object.parse (file://...mermaid-11.15.0.js:156553:11)
    at async Diagram.fromText (file://...mermaid-11.15.0.js:177444:7)
    at async Object.render (file://...mermaid-11.15.0.js:177807:14)

[stdout]
Generating single mermaid chart
```

Added a test to check that behavior.


- **Backfill CHANGELOG for 2.0.2**
- **fix: Capture mmdc error message as string**
