### PR TITLE
Fix local JS imports in our js module

### DIFF
--- a/sphinxcontrib/mermaid/default.js.j2
+++ b/sphinxcontrib/mermaid/default.js.j2
@@ -1,11 +1,18 @@
-import mermaid from "{{ mermaid_js_url }}";
+{%- macro fix_import_url(url) -%}
+{%- if url.startswith(("https://", "http://", "//", "/", "../")) -%}
+{{ url }}
+{%- else -%}
+./{{ url }}
+{%- endif -%}
+{%- endmacro -%}
+import mermaid from "{{ fix_import_url(mermaid_js_url) }}";
 
 {% if mermaid_include_elk %}
-import elkLayouts from "{{ mermaid_elk_js_url }}"
+import elkLayouts from "{{ fix_import_url(mermaid_elk_js_url) }}"
 {% endif %}
 
 {% if mermaid_include_zenuml %}
-import zenumlLayouts from "{{ mermaid_zenuml_js_url }}"
+import zenumlLayouts from "{{ fix_import_url(mermaid_zenuml_js_url) }}"
 {% endif %}
 
 const initStyles = () => {

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -77,7 +77,7 @@ def test_conf_mermaid_version(app, index):
 def test_conf_mermaid_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
-    assert 'import mermaid from "_static/test"' in index
+    assert 'import mermaid from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_elk": True, "mermaid_elk_use_local": "test"})
@@ -85,7 +85,7 @@ def test_conf_mermaid_elk_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
     assert "mermaid-layout-elk.esm.min.mjs" not in index
-    assert 'import elkLayouts from "_static/test"' in index
+    assert 'import elkLayouts from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_zenuml": True, "mermaid_zenuml_use_local": "test"})
@@ -93,7 +93,7 @@ def test_conf_mermaid_zenuml_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
     assert "mermaid-zenuml.esm.min.mjs" not in index
-    assert 'import zenumlLayouts from "_static/test"' in index
+    assert 'import zenumlLayouts from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"d3_version": "1.2.3", "mermaid_include_elk": False})


### PR DESCRIPTION
This patch fixes an issue with un-remapped bare imports in the mermaid module import logic.

It does so by modifying the jinja2 template for the `.js` block in order to
ensure that relatives paths in the same directory to the current page lead with
a `./` (which is what browser JS expects). Tests have been updated to correctly
detect the valid imports.

Fixes: #246 
