### PR TITLE
Fix local JS module imports on root-level pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Capture mmdc error message as string for nicer error display
+- Fix local JS module imports on root-level pages by ensuring a valid relative ES module specifier (#246)
 
 ## 2.0.2 (April 30, 2026)
 

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -406,7 +406,14 @@ def _resolve_local_url(url: str, context: dict) -> str:
     """
     if not url or url.startswith(("http://", "https://", "//", "/")):
         return url
-    return context["pathto"]("_static/" + url, resource=True)
+    resolved = context["pathto"]("_static/" + url, resource=True)
+    # ``pathto`` omits the leading ``./`` when the target is at the same
+    # directory level as the current page. A bare relative path is an invalid
+    # ES module specifier (it is treated as a package name), so ensure the
+    # result is a valid relative import. See issue #246.
+    if not resolved.startswith(("./", "../", "/")):
+        resolved = "./" + resolved
+    return resolved
 
 
 def install_js(

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -77,7 +77,7 @@ def test_conf_mermaid_version(app, index):
 def test_conf_mermaid_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
-    assert 'import mermaid from "_static/test"' in index
+    assert 'import mermaid from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_elk": True, "mermaid_elk_use_local": "test"})
@@ -85,7 +85,7 @@ def test_conf_mermaid_elk_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
     assert "mermaid-layout-elk.esm.min.mjs" not in index
-    assert 'import elkLayouts from "_static/test"' in index
+    assert 'import elkLayouts from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_zenuml": True, "mermaid_zenuml_use_local": "test"})
@@ -93,7 +93,7 @@ def test_conf_mermaid_zenuml_local(app, index):
     assert "mermaid.run()" in index
     assert "mermaid.min.js" not in index
     assert "mermaid-zenuml.esm.min.mjs" not in index
-    assert 'import zenumlLayouts from "_static/test"' in index
+    assert 'import zenumlLayouts from "./_static/test"' in index
 
 
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"d3_version": "1.2.3", "mermaid_include_elk": False})


### PR DESCRIPTION
pathto omits the leading ./ when the target is at the same directory level as the current page, producing a bare ES module specifier that fails to import. Normalize the resolved path to a valid relative specifier.

Fixes #246
Closes #247 