### PR TITLE
Remove "Project unmaintained" notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-> [!NOTE]
-> `sphinxcontrib-mermaid` is actively seeking new maintainers.
-> As the original creator, I'm no longer able to dedicate the time and
-> attention needed. If you're interested in contributing and helping to
-> drive this project forward, please see [this
-> issue](https://github.com/mgaitan/sphinxcontrib-mermaid/issues/148).
-
 # sphinxcontrib-mermaid
 
 [![test status](https://github.com/mgaitan/sphinxcontrib-mermaid/actions/workflows/test.yml/badge.svg)](https://github.com/mgaitan/sphinxcontrib-mermaid/actions/workflows/test.yml)


### PR DESCRIPTION
Issue #148 is closed and the project has a maintainer again. Remove
the warning from the README, which might prevent people from using an
otherwise maintained and working extension.
