### PR TITLE
Skip JavaScript for static Mermaid output

### DIFF
--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -426,6 +426,10 @@ def install_js(
     context: dict,
     doctree: nodes.document | None,
 ) -> None:
+    # Build-time PNG and SVG output does not need client-side rendering.
+    if app.config.mermaid_output_format != "raw":
+        return
+
     # Skip for pages without Mermaid diagrams
     if doctree and not doctree.next_node(mermaid):
         return

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -263,3 +263,22 @@ def test_render_error_message(app):
     app.builder.build_all()
     warnings = app._warning.getvalue()
     assert "Mermaid exited with error:\n[stderr]\nError: bad syntax\nsomething else" in warnings
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="basic",
+    confoverrides={"mermaid_output_format": "svg"},
+)
+def test_static_output_skips_javascript(app, monkeypatch):
+    monkeypatch.setattr(
+        "sphinxcontrib.mermaid.render_mm",
+        lambda *args, **kwargs: ("diagram.svg", app.outdir / "diagram.svg"),
+    )
+
+    app.builder.build_all()
+    index = (app.outdir / "index.html").read_text()
+
+    assert "cdn.jsdelivr.net/npm/mermaid" not in index
+    assert "cdn.jsdelivr.net/npm/d3" not in index
+    assert "mermaid.run(" not in index


### PR DESCRIPTION
Replacement for #132, originally contributed by @tsibley.

Build-time PNG and SVG output does not require Mermaid or D3 client-side rendering. This rebases the original behavior onto current master and adds regression coverage verifying that static SVG output includes neither Mermaid nor D3 JavaScript.
