### PR TITLE
Fix mermaid sequence config type

### DIFF
--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -578,7 +578,7 @@ def setup(app):
     app.add_config_value("mermaid_output_format", "raw", "html")
     app.add_config_value("mermaid_params", list(), "html")
     app.add_config_value("mermaid_verbose", False, "html")
-    app.add_config_value("mermaid_sequence_config", False, "html")
+    app.add_config_value("mermaid_sequence_config", None, "html")
     app.add_config_value("mermaid_config", None, "env")
 
     app.add_config_value("mermaid_init_config", {"startOnLoad": False}, "html")

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -81,6 +81,16 @@ def test_conf_mermaid_version(app, index):
     )
 
 
+@pytest.mark.sphinx(
+    "html",
+    testroot="basic",
+    confoverrides={"mermaid_sequence_config": "mermaid.json"},
+)
+def test_conf_mermaid_sequence_config(app, index):
+    assert app.config.mermaid_sequence_config == "mermaid.json"
+    assert "defaults to `NoneType`" not in app._warning.getvalue()
+
+
 @pytest.mark.sphinx("html", testroot="basic", confoverrides={"mermaid_use_local": "test", "mermaid_include_elk": False})
 def test_conf_mermaid_local(app, index):
     assert "mermaid.run(" in index


### PR DESCRIPTION
Set the default for `mermaid_sequence_config` to `None` so Sphinx accepts configured string paths without a type warning. The value remains falsey when unset.

Adds a regression test for a string configuration path.

Closes #103.