### PR TITLE
Add Mermaid icon pack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,25 @@ See [`mermaid_use_local`](#mermaid_use_local) for accepted values.
 Optional location of a local copy of `mermaid-zenuml.esm.min.mjs`.
 See [`mermaid_use_local`](#mermaid_use_local) for accepted values.
 
+### `mermaid_icon_packs`
+
+Optional mapping of icon-pack names to
+[Iconify JSON URLs](https://mermaid.js.org/config/icons.html). Packs are
+registered lazily and fetched only when Mermaid uses an icon from them.
+Relative paths are resolved from `html_static_path`. This option applies to raw
+HTML output only.
+
+For example:
+
+```python
+mermaid_icon_packs = {
+    "logos": "https://cdn.jsdelivr.net/npm/@iconify-json/logos@1/icons.json",
+}
+```
+
+Icons from the pack can then be referenced with the registered name, such as
+`logos:aws-lambda` in an architecture diagram.
+
 ### `d3_use_local`
 
 Optional location of a local copy of `d3.min.js`.

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -471,6 +471,8 @@ def install_js(
                 f"https://cdn.jsdelivr.net/npm/@mermaid-js/mermaid-zenuml@{app.config.mermaid_zenuml_version}/dist/mermaid-zenuml.esm.min.mjs"
             )
 
+    _mermaid_icon_packs = {name: _resolve_local_url(url, context) for name, url in app.config.mermaid_icon_packs.items()}
+
     _wrote_mermaid_run = False
     _d3_selector = ""
     _d3_node_count = 0
@@ -506,6 +508,8 @@ def install_js(
         mermaid_include_zenuml=_mermaid_zenuml_js_url is not None,
         mermaid_elk_js_url=_dump_js(_mermaid_elk_js_url),
         mermaid_zenuml_js_url=_dump_js(_mermaid_zenuml_js_url),
+        mermaid_include_icon_packs=bool(_mermaid_icon_packs),
+        mermaid_icon_packs=_dump_js(_mermaid_icon_packs),
         common_css=_dump_js(
             template_css.render(
                 mermaid_width=_mermaid_width,
@@ -594,6 +598,7 @@ def setup(app):
     app.add_config_value("mermaid_zenuml_version", "0.2.2", "html")
     app.add_config_value("mermaid_elk_use_local", "", "html")
     app.add_config_value("mermaid_zenuml_use_local", "", "html")
+    app.add_config_value("mermaid_icon_packs", {}, "html")
 
     app.add_config_value("d3_use_local", "", "html")
     app.add_config_value("d3_version", "7.9.0", "html")

--- a/sphinxcontrib/mermaid/default.js.j2
+++ b/sphinxcontrib/mermaid/default.js.j2
@@ -4,6 +4,14 @@ import mermaid from {{ mermaid_js_url }};
 import elkLayouts from {{ mermaid_elk_js_url }}
 {% endif %}
 
+{% if mermaid_include_icon_packs %}
+const iconPacks = {{ mermaid_icon_packs }};
+mermaid.registerIconPacks(Object.entries(iconPacks).map(([name, url]) => ({
+    name,
+    loader: () => fetch(url).then((response) => response.json()),
+})));
+{% endif %}
+
 const initStyles = () => {
     const defaultStyle = document.createElement('style');
     defaultStyle.textContent = {{ common_css }};

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -32,6 +32,7 @@ def test_html_raw(index):
         'mermaid.registerLayoutLoaders(elkLayouts);'
         in index
     )
+    assert "mermaid.registerIconPacks" not in index
     assert (
         '{"startOnLoad": false}'
         in index
@@ -102,6 +103,23 @@ def test_conf_mermaid_zenuml_local(app, index):
     assert "mermaid.min.js" not in index
     assert "mermaid-zenuml.esm.min.mjs" not in index
     assert 'import("./_static/test")' in index
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="basic",
+    confoverrides={
+        "mermaid_icon_packs": {
+            "logos": "https://cdn.jsdelivr.net/npm/@iconify-json/logos@1/icons.json",
+            "local": "icons.json",
+        },
+    },
+)
+def test_conf_mermaid_icon_packs(index):
+    assert '"logos": "https://cdn.jsdelivr.net/npm/@iconify-json/logos@1/icons.json"' in index
+    assert '"local": "./_static/icons.json"' in index
+    assert "mermaid.registerIconPacks(Object.entries(iconPacks)" in index
+    assert "loader: () => fetch(url).then((response) => response.json())" in index
 
 
 @pytest.mark.sphinx(


### PR DESCRIPTION
Add an opt-in `mermaid_icon_packs` mapping for registering remote or locally vendored Iconify JSON packs with Mermaid. Packs use Mermaid's lazy loader, so they are fetched only when referenced by a diagram.

Document configuration and cover disabled, remote, and local-path behavior.

Closes #213.