### PR TITLE
Add class to static Mermaid images

### DIFF
--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -317,7 +317,7 @@ def render_mm_html(self, node, code, options, prefix="mermaid", imgcls=None, alt
 
 
 def html_visit_mermaid(self, node):
-    render_mm_html(self, node, node["code"], node["options"])
+    render_mm_html(self, node, node["code"], node["options"], imgcls="mermaid")
 
 
 def render_mm_latex(self, node, code, options, prefix="mermaid"):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -319,3 +319,20 @@ def test_static_output_skips_javascript(app, monkeypatch):
     assert "cdn.jsdelivr.net/npm/mermaid" not in index
     assert "cdn.jsdelivr.net/npm/d3" not in index
     assert "mermaid.run(" not in index
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="basic",
+    confoverrides={"mermaid_output_format": "png"},
+)
+def test_static_png_has_mermaid_class(app, monkeypatch):
+    monkeypatch.setattr(
+        "sphinxcontrib.mermaid.render_mm",
+        lambda *args, **kwargs: ("diagram.png", app.outdir / "diagram.png"),
+    )
+
+    app.builder.build_all()
+    index = (app.outdir / "index.html").read_text()
+
+    assert re.search(r'<img src="diagram\.png"[^>]* class="mermaid"', index)


### PR DESCRIPTION
Pass the existing `mermaid` image class through the HTML visitor so PNG output can be targeted consistently with CSS.

Adds a regression test for generated static PNG markup.

Closes #121.