### PR TITLE
Add Mermaid caption translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ name: test
 - `config`: JSON to pass through to the [mermaid configuration](https://mermaid.js.org/config/configuration.html). **NOTE**: The mermaid documentation uses YAML, but we must use JSON because Markdown processing of frontmatter will interfere.
 - `title`: Title to pass through to the [mermaid configuration](https://mermaid.js.org/config/configuration.html)
 
+## Translations
+
+For translated diagrams, store Mermaid source in an external `.mmd` file and
+provide localized files using Sphinx's
+[`figure_language_filename`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-figure_language_filename)
+convention. For example, `diagram.mmd` and `diagram.de.mmd` can be referenced by
+the same directive, and Sphinx selects the file matching the active language.
+
+Mermaid captions are included in gettext catalogs and translated like other
+figure captions. Inline Mermaid source is not extracted as prose; use localized
+external files when diagram labels need translation.
+
 ## Config values
 
 ### `mermaid_output_format`

--- a/sphinxcontrib/mermaid/__init__.py
+++ b/sphinxcontrib/mermaid/__init__.py
@@ -34,6 +34,7 @@ from sphinx.application import Sphinx
 from sphinx.locale import _
 from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
+from sphinx.util.nodes import set_source_info
 from sphinx.util.osutil import ensuredir
 from yaml import dump
 
@@ -68,8 +69,7 @@ def figure_wrapper(directive, node, caption):
     parsed = nodes.Element()
     directive.state.nested_parse(ViewList([caption], source=""), directive.content_offset, parsed)
     caption_node = nodes.caption(parsed[0].rawsource, "", *parsed[0].children)
-    caption_node.source = parsed[0].source
-    caption_node.line = parsed[0].line
+    set_source_info(directive, caption_node)
     figure_node += caption_node
     return figure_node
 

--- a/tests/roots/test-i18n/conf.py
+++ b/tests/roots/test-i18n/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sphinxcontrib.mermaid"]
+exclude_patterns = ["_build"]

--- a/tests/roots/test-i18n/index.rst
+++ b/tests/roots/test-i18n/index.rst
@@ -1,0 +1,8 @@
+Translated Mermaid caption
+==========================
+
+.. mermaid::
+   :caption: A translatable diagram
+
+   flowchart LR
+      A --> B

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.sphinx("gettext", testroot="i18n")
+def test_mermaid_caption_is_extracted(app):
+    app.builder.build_all()
+
+    catalog = (app.outdir / "index.pot").read_text()
+
+    assert 'msgid "A translatable diagram"' in catalog
+    assert "flowchart LR" not in catalog


### PR DESCRIPTION
Preserve source metadata on generated Mermaid caption nodes so Sphinx extracts them into gettext catalogs and applies normal caption translations. Mermaid source remains excluded from prose catalogs.

Document the existing localized external-file workflow and add gettext regression coverage.

Closes #130.